### PR TITLE
Improve theme application reliability and EDHM status controls

### DIFF
--- a/source_v3/src/Helpers/FileHelper.js
+++ b/source_v3/src/Helpers/FileHelper.js
@@ -1,4 +1,4 @@
-import { app, ipcMain, dialog, shell, clipboard, net, } from 'electron';
+import { app, ipcMain, BrowserWindow, dialog, shell, clipboard, net, } from 'electron';
 import { exec, execSync, execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import path from 'node:path';
@@ -971,8 +971,10 @@ function isProcessRunning(name) {
             const output = execSync("tasklist").toString().toLowerCase();
             return output.includes(name.toLowerCase());
 
-        } else if (platform === "linux") {
-            const output = execSync("ps -A").toString().toLowerCase();
+        } else if (platform === "linux" || platform === "darwin") {
+            // Include both the executable name and full arguments. Wine/Proton
+            // process names can otherwise be truncated in the default ps output.
+            const output = execSync("ps -A -o comm= -o args=").toString().toLowerCase();
             return output.includes(name.toLowerCase());
 
         } else {
@@ -1412,7 +1414,10 @@ ipcMain.handle('ShowMessageBox', async (event, options) => {
       if (result && result.response === 1) { }
   */
   try {
-    const result = await dialog.showMessageBox(options);
+    const parentWindow = BrowserWindow.fromWebContents(event.sender);
+    const result = parentWindow
+      ? await dialog.showMessageBox(parentWindow, options)
+      : await dialog.showMessageBox(options);
     return result;
   } catch (error) {
     throw new Error(error.message + error.stack);
@@ -1966,7 +1971,7 @@ export default {
 
   createWindowsShortcut,
   createLinuxShortcut,
-  terminateProgram,
+  isProcessRunning, terminateProgram,
   runInstaller, runScripOrProgram,
 
   copyToClipboard,

--- a/source_v3/src/Helpers/SettingsHelper.js
+++ b/source_v3/src/Helpers/SettingsHelper.js
@@ -867,6 +867,7 @@ async function ApplyTheme(themeName) {
             console.log(counter + ' ' + counterName + ' added!');
           } catch (error) {
             console.log('ERROR @SettingsHelper.applyTheme().applySettings():', error);
+            throw error;
           }
         }
 
@@ -888,15 +889,22 @@ async function ApplyTheme(themeName) {
         const updatedInis = await themeHelper.ApplyTemplateValuesToIni(template, defaultINIs);
         console.log('7. Applying Changes to the INIs...', updatedInis != undefined);
 
-        const _curSettsSAved = await themeHelper.SaveTheme(template);
-        console.log('Current Settings Saved?: ', _curSettsSAved);
-
         console.log('8. Saving the INI files..');
-        const _ret = await themeHelper.SaveThemeINIs(GamePath, updatedInis);
-        if (_ret) {
-          console.log('9. Theme Applied!', _ret);
-          return true;
+        const inisSaved = await themeHelper.SaveThemeINIs(GamePath, updatedInis);
+        if (!inisSaved) {
+          throw new Error('One or more theme INI files could not be saved.');
         }
+
+        // ThemeSettings.json is the in-game reload signal, so write it only
+        // after every INI has been saved successfully.
+        const currentSettingsSaved = await themeHelper.SaveTheme(template);
+        console.log('9. Current Settings Saved?: ', currentSettingsSaved);
+        if (!currentSettingsSaved) {
+          throw new Error('Theme INIs were saved, but ThemeSettings.json could not be updated.');
+        }
+
+        console.log('10. Theme Applied!');
+        return true;
       }
       else {
         console.log('Theme Not Found!', themeName);

--- a/source_v3/src/Helpers/SettingsHelper.js
+++ b/source_v3/src/Helpers/SettingsHelper.js
@@ -588,12 +588,18 @@ async function installEDHMmod(gameInstance) {
 
       const _ret = await fileHelper.decompressFile(edhmZipFile, unzipGamePath);
 
-      // Installing EDHM means returning to the enabled state. Remove a stale
-      // disabled copy only after the new DLL was extracted successfully.
-      const installedDllPath = path.join(gamePath, 'd3d11.dll');
-      const disabledDllPath = path.join(gamePath, 'd3d11.dll.disabled');
-      if (_ret && await fileExists(installedDllPath) && await fileExists(disabledDllPath)) {
-        await unlink(disabledDllPath);
+      // Installing EDHM means returning both proxy DLLs to the enabled state.
+      // Remove stale disabled copies only after the complete pair was extracted.
+      const enabledPairInstalled = await Promise.all(
+        EDHM_DLL_FILES.map(({ enabled }) => fileExists(path.join(gamePath, enabled)))
+      );
+      if (_ret && enabledPairInstalled.every(Boolean)) {
+        for (const { disabled } of EDHM_DLL_FILES) {
+          const disabledPath = path.join(gamePath, disabled);
+          if (await fileExists(disabledPath)) {
+            await unlink(disabledPath);
+          }
+        }
       }
 
       Response.game = GameType;
@@ -679,6 +685,7 @@ async function UninstallEDHMmod(gameInstance) {
       'd3d11.dll.disabled',
       'd3dcompiler_46.dll',
       'd3dcompiler_47.dll',
+      'd3dcompiler_47.dll.disabled',
       'nvapi64.dll',
       'EDHM-Uninstall.bat',
     ];
@@ -708,8 +715,10 @@ async function UninstallEDHMmod(gameInstance) {
   return fileDeleted;
 };
 
-const EDHM_DLL_NAME = 'd3d11.dll';
-const EDHM_DISABLED_DLL_NAME = 'd3d11.dll.disabled';
+const EDHM_DLL_FILES = [
+  { enabled: 'd3d11.dll', disabled: 'd3d11.dll.disabled' },
+  { enabled: 'd3dcompiler_47.dll', disabled: 'd3dcompiler_47.dll.disabled' },
+];
 
 const fileExists = async (filePath) => {
   try {
@@ -731,24 +740,47 @@ async function GetEDHMStatus(gameInstance) {
   }
 
   const gamePath = path.resolve(fileHelper.resolveEnvVariables(configuredPath));
-  const enabledPath = path.join(gamePath, EDHM_DLL_NAME);
-  const disabledPath = path.join(gamePath, EDHM_DISABLED_DLL_NAME);
-  const [enabledExists, disabledExists] = await Promise.all([
-    fileExists(enabledPath),
-    fileExists(disabledPath),
-  ]);
+  const fileStates = await Promise.all(
+    EDHM_DLL_FILES.map(async ({ enabled, disabled }) => ({
+      enabled,
+      disabled,
+      enabledExists: await fileExists(path.join(gamePath, enabled)),
+      disabledExists: await fileExists(path.join(gamePath, disabled)),
+    }))
+  );
+  const allEnabled = fileStates.every(
+    ({ enabledExists, disabledExists }) => enabledExists && !disabledExists
+  );
+  const allDisabled = fileStates.every(
+    ({ enabledExists, disabledExists }) => !enabledExists && disabledExists
+  );
+  const anyDllExists = fileStates.some(
+    ({ enabledExists, disabledExists }) => enabledExists || disabledExists
+  );
 
-  if (enabledExists) {
+  if (allEnabled) {
     return {
       state: 'ready',
-      conflict: disabledExists,
+      conflict: false,
       gamePath,
     };
   }
-  if (disabledExists) {
+  if (allDisabled) {
     return {
       state: 'disabled',
       conflict: false,
+      gamePath,
+    };
+  }
+  if (anyDllExists) {
+    const d3d11State = fileStates[0];
+    return {
+      state: d3d11State.enabledExists
+        ? 'ready'
+        : d3d11State.disabledExists
+          ? 'disabled'
+          : 'not_installed',
+      conflict: true,
       gamePath,
     };
   }
@@ -759,18 +791,19 @@ async function GetEDHMStatus(gameInstance) {
   };
 }
 
-/** Toggles EDHM by renaming its local D3D11 proxy beside the game executable. */
+/** Toggles EDHM by renaming both proxy DLLs beside the game executable. */
 async function ToggleEDHMmod(gameInstance) {
   const status = await GetEDHMStatus(gameInstance);
 
-  if (status.state === 'not_installed') {
-    return { ...status, changed: false };
-  }
   if (status.conflict) {
     throw new Error(
-      `Both ${EDHM_DLL_NAME} and ${EDHM_DISABLED_DLL_NAME} exist in the game folder. ` +
-      'Resolve the duplicate files before toggling EDHM.'
+      'The EDHM DLL files are not in a matching state. Expected both d3d11.dll and ' +
+      'd3dcompiler_47.dll to be enabled, or both to have the .disabled extension. ' +
+      'Reinstall EDHM or correct the filenames before toggling it.'
     );
+  }
+  if (status.state === 'not_installed') {
+    return { ...status, changed: false };
   }
   if (fileHelper.isProcessRunning('EliteDangerous64.exe')) {
     throw new Error(
@@ -778,19 +811,35 @@ async function ToggleEDHMmod(gameInstance) {
     );
   }
 
-  const enabledPath = path.join(status.gamePath, EDHM_DLL_NAME);
-  const disabledPath = path.join(status.gamePath, EDHM_DISABLED_DLL_NAME);
   const disabling = status.state === 'ready';
-  const sourcePath = disabling ? enabledPath : disabledPath;
-  const destinationPath = disabling ? disabledPath : enabledPath;
+  const renamePairs = EDHM_DLL_FILES.map(({ enabled, disabled }) => ({
+    sourcePath: path.join(status.gamePath, disabling ? enabled : disabled),
+    destinationPath: path.join(status.gamePath, disabling ? disabled : enabled),
+  }));
+  const completedRenames = [];
 
   try {
-    await rename(sourcePath, destinationPath);
+    for (const renamePair of renamePairs) {
+      await rename(renamePair.sourcePath, renamePair.destinationPath);
+      completedRenames.push(renamePair);
+    }
   } catch (error) {
+    const rollbackErrors = [];
+    for (const renamePair of completedRenames.reverse()) {
+      try {
+        await rename(renamePair.destinationPath, renamePair.sourcePath);
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
     const action = disabling ? 'disable' : 'enable';
+    const rollbackMessage = rollbackErrors.length > 0
+      ? ' One or more DLLs could not be restored; reinstall EDHM to repair the matching state.'
+      : '';
     throw new Error(
       `Unable to ${action} EDHM: ${error.message}. ` +
-      'Ensure Elite Dangerous is not running and that the game folder is writable.'
+      'Ensure Elite Dangerous is not running and that the game folder is writable.' +
+      rollbackMessage
     );
   }
 

--- a/source_v3/src/Helpers/SettingsHelper.js
+++ b/source_v3/src/Helpers/SettingsHelper.js
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import fs from 'fs';
 import { readdir, stat } from 'fs/promises';
-import { writeFile, unlink, access } from 'node:fs/promises';
+import { writeFile, unlink, access, rename } from 'node:fs/promises';
 
 import fileHelper from './FileHelper';
 import themeHelper from './ThemeHelper.js';
@@ -588,6 +588,14 @@ async function installEDHMmod(gameInstance) {
 
       const _ret = await fileHelper.decompressFile(edhmZipFile, unzipGamePath);
 
+      // Installing EDHM means returning to the enabled state. Remove a stale
+      // disabled copy only after the new DLL was extracted successfully.
+      const installedDllPath = path.join(gamePath, 'd3d11.dll');
+      const disabledDllPath = path.join(gamePath, 'd3d11.dll.disabled');
+      if (_ret && await fileExists(installedDllPath) && await fileExists(disabledDllPath)) {
+        await unlink(disabledDllPath);
+      }
+
       Response.game = GameType;
       Response.version = versionMatch[0];
 
@@ -668,6 +676,7 @@ async function UninstallEDHMmod(gameInstance) {
       'ShaderFixes',
       'd3dx.ini',
       'd3d11.dll',
+      'd3d11.dll.disabled',
       'd3dcompiler_46.dll',
       'd3dcompiler_47.dll',
       'nvapi64.dll',
@@ -699,8 +708,94 @@ async function UninstallEDHMmod(gameInstance) {
   return fileDeleted;
 };
 
-async function DisableEDHMmod(gameInstance) {
-  throw new Error("Not implemented yet!");  
+const EDHM_DLL_NAME = 'd3d11.dll';
+const EDHM_DISABLED_DLL_NAME = 'd3d11.dll.disabled';
+
+const fileExists = async (filePath) => {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    if (error.code === 'ENOENT') return false;
+    throw error;
+  }
+};
+
+/** Returns EDHM's enabled, disabled, or not-installed state for a game instance. */
+async function GetEDHMStatus(gameInstance) {
+  const configuredPath = Array.isArray(gameInstance?.path)
+    ? gameInstance.path[0]
+    : gameInstance?.path;
+  if (!configuredPath) {
+    return { state: 'not_installed', conflict: false };
+  }
+
+  const gamePath = path.resolve(fileHelper.resolveEnvVariables(configuredPath));
+  const enabledPath = path.join(gamePath, EDHM_DLL_NAME);
+  const disabledPath = path.join(gamePath, EDHM_DISABLED_DLL_NAME);
+  const [enabledExists, disabledExists] = await Promise.all([
+    fileExists(enabledPath),
+    fileExists(disabledPath),
+  ]);
+
+  if (enabledExists) {
+    return {
+      state: 'ready',
+      conflict: disabledExists,
+      gamePath,
+    };
+  }
+  if (disabledExists) {
+    return {
+      state: 'disabled',
+      conflict: false,
+      gamePath,
+    };
+  }
+  return {
+    state: 'not_installed',
+    conflict: false,
+    gamePath,
+  };
+}
+
+/** Toggles EDHM by renaming its local D3D11 proxy beside the game executable. */
+async function ToggleEDHMmod(gameInstance) {
+  const status = await GetEDHMStatus(gameInstance);
+
+  if (status.state === 'not_installed') {
+    return { ...status, changed: false };
+  }
+  if (status.conflict) {
+    throw new Error(
+      `Both ${EDHM_DLL_NAME} and ${EDHM_DISABLED_DLL_NAME} exist in the game folder. ` +
+      'Resolve the duplicate files before toggling EDHM.'
+    );
+  }
+  if (fileHelper.isProcessRunning('EliteDangerous64.exe')) {
+    throw new Error(
+      'Elite Dangerous is currently running. Close the game before enabling or disabling EDHM.'
+    );
+  }
+
+  const enabledPath = path.join(status.gamePath, EDHM_DLL_NAME);
+  const disabledPath = path.join(status.gamePath, EDHM_DISABLED_DLL_NAME);
+  const disabling = status.state === 'ready';
+  const sourcePath = disabling ? enabledPath : disabledPath;
+  const destinationPath = disabling ? disabledPath : enabledPath;
+
+  try {
+    await rename(sourcePath, destinationPath);
+  } catch (error) {
+    const action = disabling ? 'disable' : 'enable';
+    throw new Error(
+      `Unable to ${action} EDHM: ${error.message}. ` +
+      'Ensure Elite Dangerous is not running and that the game folder is writable.'
+    );
+  }
+
+  const updatedStatus = await GetEDHMStatus(gameInstance);
+  return { ...updatedStatus, changed: true };
 }
 
 /** This are actions to be run after an App Update is applied and Before EDHM mod is installed. */
@@ -1095,11 +1190,26 @@ ipcMain.handle('UninstallEDHMmod', (event, gameInstance) => {
     throw new Error(error.message + error.stack);
   }
 });
-ipcMain.handle('DisableEDHMmod', (event, gameInstance) => {
+ipcMain.handle('GetEDHMStatus', async (event, gameInstance) => {
   try {
-    return DisableEDHMmod(gameInstance);
+    return await GetEDHMStatus(gameInstance);
   } catch (error) {
-    throw new Error(error.message + error.stack);
+    throw new Error(error.message);
+  }
+});
+ipcMain.handle('ToggleEDHMmod', async (event, gameInstance) => {
+  try {
+    return await ToggleEDHMmod(gameInstance);
+  } catch (error) {
+    throw new Error(error.message);
+  }
+});
+// Backwards-compatible alias for older renderer bundles.
+ipcMain.handle('DisableEDHMmod', async (event, gameInstance) => {
+  try {
+    return await ToggleEDHMmod(gameInstance);
+  } catch (error) {
+    throw new Error(error.message);
   }
 });
 

--- a/source_v3/src/Helpers/SettingsHelper.js
+++ b/source_v3/src/Helpers/SettingsHelper.js
@@ -748,44 +748,36 @@ async function GetEDHMStatus(gameInstance) {
       disabledExists: await fileExists(path.join(gamePath, disabled)),
     }))
   );
-  const allEnabled = fileStates.every(
-    ({ enabledExists, disabledExists }) => enabledExists && !disabledExists
-  );
-  const allDisabled = fileStates.every(
-    ({ enabledExists, disabledExists }) => !enabledExists && disabledExists
-  );
   const anyDllExists = fileStates.some(
     ({ enabledExists, disabledExists }) => enabledExists || disabledExists
   );
+  const anyDisabled = fileStates.some(({ disabledExists }) => disabledExists);
+  const hasDuplicate = fileStates.some(
+    ({ enabledExists, disabledExists }) => enabledExists && disabledExists
+  );
+  const hasMissing = fileStates.some(
+    ({ enabledExists, disabledExists }) => !enabledExists && !disabledExists
+  );
 
-  if (allEnabled) {
+  if (!anyDllExists) {
     return {
-      state: 'ready',
+      state: 'not_installed',
       conflict: false,
       gamePath,
     };
   }
-  if (allDisabled) {
+  if (hasDuplicate || hasMissing) {
     return {
-      state: 'disabled',
-      conflict: false,
-      gamePath,
-    };
-  }
-  if (anyDllExists) {
-    const d3d11State = fileStates[0];
-    return {
-      state: d3d11State.enabledExists
-        ? 'ready'
-        : d3d11State.disabledExists
-          ? 'disabled'
-          : 'not_installed',
+      state: anyDisabled ? 'disabled' : 'ready',
       conflict: true,
       gamePath,
     };
   }
+
+  // A mixed pair is still disabled. This lets Enable repair the pair by
+  // restoring whichever member currently has the .disabled extension.
   return {
-    state: 'not_installed',
+    state: anyDisabled ? 'disabled' : 'ready',
     conflict: false,
     gamePath,
   };
@@ -797,9 +789,8 @@ async function ToggleEDHMmod(gameInstance) {
 
   if (status.conflict) {
     throw new Error(
-      'The EDHM DLL files are not in a matching state. Expected both d3d11.dll and ' +
-      'd3dcompiler_47.dll to be enabled, or both to have the .disabled extension. ' +
-      'Reinstall EDHM or correct the filenames before toggling it.'
+      'The EDHM DLL files are incomplete or duplicated. Each DLL must have exactly ' +
+      'one enabled or disabled filename. Reinstall EDHM or correct the files before toggling it.'
     );
   }
   if (status.state === 'not_installed') {
@@ -812,10 +803,19 @@ async function ToggleEDHMmod(gameInstance) {
   }
 
   const disabling = status.state === 'ready';
-  const renamePairs = EDHM_DLL_FILES.map(({ enabled, disabled }) => ({
-    sourcePath: path.join(status.gamePath, disabling ? enabled : disabled),
-    destinationPath: path.join(status.gamePath, disabling ? disabled : enabled),
-  }));
+  const renamePairs = [];
+  for (const { enabled, disabled } of EDHM_DLL_FILES) {
+    const enabledPath = path.join(status.gamePath, enabled);
+    const disabledPath = path.join(status.gamePath, disabled);
+    // When repairing a mixed disabled pair, rename only the member that is
+    // disabled and leave an already-enabled member untouched.
+    if (disabling || await fileExists(disabledPath)) {
+      renamePairs.push({
+        sourcePath: disabling ? enabledPath : disabledPath,
+        destinationPath: disabling ? disabledPath : enabledPath,
+      });
+    }
+  }
   const completedRenames = [];
 
   try {

--- a/source_v3/src/Helpers/ThemeHelper.js
+++ b/source_v3/src/Helpers/ThemeHelper.js
@@ -749,21 +749,45 @@ const getIniFilePath = (basePath, fileName) => {
  * @returns Object */
 const LoadThemeINIs = async (folderPath) => {
   try {
+    const iniFiles = [
+      ['Startup-Profile.ini', 'StartupProfile'],
+      ['Advanced.ini', 'Advanced'],
+      ['SuitHud.ini', 'SuitHud'],
+      ['XML-Profile.ini', 'XmlProfile'],
+      ['Custom.ini', 'Custom'],
+    ];
+    const availableFiles = iniFiles.filter(([fileName]) =>
+      fs.existsSync(getIniFilePath(folderPath, fileName))
+    );
 
-    const [Startup_Profile, Advanced, SuitHud, XML_Profile] = await Promise.all([
-      await INIparser.LoadIniFile(getIniFilePath(folderPath, 'Startup-Profile.ini')),
-      await INIparser.LoadIniFile(getIniFilePath(folderPath, 'Advanced.ini')),
-      await INIparser.LoadIniFile(getIniFilePath(folderPath, 'SuitHud.ini')),
-      await INIparser.LoadIniFile(getIniFilePath(folderPath, 'XML-Profile.ini')),
-    ]);
-
-    return {
-      path: folderPath,
-      StartupProfile: Startup_Profile,
-      Advanced: Advanced,
-      SuitHud: SuitHud,
-      XmlProfile: XML_Profile
+    if (availableFiles.length === 0) {
+      throw new Error(`No theme INI files were found in: ${folderPath}`);
     }
+
+    const results = await Promise.all(
+      availableFiles.map(([fileName]) => INIparser.LoadIniFile(getIniFilePath(folderPath, fileName)))
+    );
+    const failedFiles = availableFiles
+      .filter((_, index) => !results[index])
+      .map(([fileName]) => fileName);
+
+    if (failedFiles.length > 0) {
+      throw new Error(`Failed to load theme INI files: ${failedFiles.join(', ')}`);
+    }
+
+    const loadedINIs = {
+      path: folderPath,
+      StartupProfile: null,
+      Advanced: null,
+      SuitHud: null,
+      XmlProfile: null,
+      Custom: null,
+    };
+    availableFiles.forEach(([, propertyName], index) => {
+      loadedINIs[propertyName] = results[index];
+    });
+
+    return loadedINIs;
 
   } catch (error) {
     throw new Error(error.message + error.stack);
@@ -776,12 +800,31 @@ const LoadThemeINIs = async (folderPath) => {
  * @returns boolean 'true' is save is successful. */
 const SaveThemeINIs = async (folderPath, themeINIs) => {
   try {
-    await Promise.all([
-      await INIparser.SaveIniFile(getIniFilePath(folderPath, 'Startup-Profile.ini'), themeINIs.StartupProfile),
-      await INIparser.SaveIniFile(getIniFilePath(folderPath, 'Advanced.ini'), themeINIs.Advanced),
-      await INIparser.SaveIniFile(getIniFilePath(folderPath, 'SuitHud.ini'), themeINIs.SuitHud),
-      await INIparser.SaveIniFile(getIniFilePath(folderPath, 'XML-Profile.ini'), themeINIs.XmlProfile),
-    ]);
+    const iniFiles = [
+      ['Startup-Profile.ini', themeINIs?.StartupProfile],
+      ['Advanced.ini', themeINIs?.Advanced],
+      ['SuitHud.ini', themeINIs?.SuitHud],
+      ['XML-Profile.ini', themeINIs?.XmlProfile],
+      ['Custom.ini', themeINIs?.Custom],
+    ].filter(([, iniData]) => iniData != null);
+
+    if (iniFiles.length === 0) {
+      throw new Error('No loaded theme INI files were provided to save.');
+    }
+
+    const results = await Promise.all(
+      iniFiles.map(([fileName, iniData]) =>
+        INIparser.SaveIniFile(getIniFilePath(folderPath, fileName), iniData)
+      )
+    );
+    const failedFiles = iniFiles
+      .filter((_, index) => results[index] !== true)
+      .map(([fileName]) => fileName);
+
+    if (failedFiles.length > 0) {
+      throw new Error(`Failed to save theme INI files: ${failedFiles.join(', ')}`);
+    }
+
     return true;
 
   } catch (error) {

--- a/source_v3/src/MainWindow/App.vue
+++ b/source_v3/src/MainWindow/App.vue
@@ -232,6 +232,10 @@ export default {
         const NewInstance = await window.api.getInstanceByName(e.GameInstanceName);
         console.log('NewInstance:', NewInstance);
 
+        // NavBars receives its own settings copy, so persist the selected
+        // instance here before reinitializing components that read it back.
+        this.settings.ActiveInstance = e.GameInstanceName.toString();
+
         if (e.InstallMod) {
           EventBus.emit('RoastMe', { type: 'Info', message: `Installing EDHM on '${e.GameInstanceName}'..` });
           const edhmInstalled = await window.api.installEDHMmod(NewInstance);
@@ -248,6 +252,9 @@ export default {
           EventBus.emit('RoastMe', { type: 'Success', message: `EDHM ${edhmInstalled.version} Installed.` });
         }
 
+        const jsonString = JSON.stringify(this.settings, null, 4);
+        this.settings = await window.api.saveSettings(jsonString);
+
         EventBus.emit('InitializeNavBars', JSON.parse(JSON.stringify(this.settings))); //<- Event Listened at NavBars.vue
         EventBus.emit('OnInitializeThemes', JSON.parse(JSON.stringify(this.settings)));//<- Event Listened at ThemeTab.vue
         EventBus.emit('InitializeHUDimage', null);    //<- Event Listened at HudImage.vue
@@ -256,9 +263,6 @@ export default {
 
         EventBus.emit('modUpdated', this.settings);     //<- Event listen in MainNavBars.vue
         EventBus.emit('loadThemes', this.settings.FavToogle);  //<- this event will be heard in 'ThemeTab.vue'
-
-        const jsonString = JSON.stringify(this.settings, null, 4);
-        await window.api.saveSettings(jsonString);
 
         this.StartShipyard();
 
@@ -799,7 +803,7 @@ export default {
           console.log(patchNotes);
 
           EventBus.emit('RoastMe', {
-            type: 'Info',
+            type: 'UpdateInfo',
             title: 'Update Available: ' + serverVersion,
             message: 'Do you want to download this update?',
             detail: patchNotes,

--- a/source_v3/src/MainWindow/App.vue
+++ b/source_v3/src/MainWindow/App.vue
@@ -747,6 +747,44 @@ export default {
         console.error('Error cargando notificación de mantenimiento:', err);
       }
     },
+
+    async StartAvailableUpdateDownload() {
+      // Keep the existing update safety check before starting the download.
+      const fullPath = await window.api.detectProgram('EliteDangerous64.exe');
+      if (fullPath) {
+        console.log('Process found at:', fullPath);
+        EventBus.emit('RoastMe', {
+          type: 'Accent', accent: 'error', background: 'warning',
+          title: 'Can NOT update!', message: 'The game is Running<br>You need to close it to allow the update to be installed<br>Try again after closing the game.',
+          width: '460px', autoHide: false
+        });
+        return false;
+      }
+
+      const platform = await window.api.getPlatform();
+      let downloadUrl = '';
+      let fileSavePath = '';
+
+      if (platform === 'win32') {
+        console.log('Running on Windows');
+        downloadUrl = 'https://github.com/BlueMystical/EDHM_UI/releases/latest/download/edhm-ui-v3-windows-x64.exe';
+        fileSavePath = await window.api.resolveEnvVariables('%LOCALAPPDATA%\\Temp\\EDHM_UI\\edhm-ui-v3-windows-x64.exe');
+      } else if (platform === 'linux') {
+        console.log('Running on Linux');
+        downloadUrl = 'https://github.com/BlueMystical/EDHM_UI/releases/latest/download/edhm-ui-v3-linux-x64.zip';
+        fileSavePath = '/tmp/EDHM_UI/edhm-ui-v3-linux-x64.zip';
+      } else {
+        throw new Error(`Updates are not supported on platform: ${platform}`);
+      }
+
+      EventBus.emit('StartDownload', {
+        url: downloadUrl,
+        save_to: fileSavePath,
+        platform,
+      });
+      return true;
+    },
+
     async AnalyseUpdate(latesRelease) {
       try {
         const localVersion = await window.api.getAppVersion();
@@ -760,61 +798,24 @@ export default {
           var patchNotes = latesRelease.notes.split("----")[0];
           console.log(patchNotes);
 
-          const options = {
-            type: 'question', //<- none, info, error, question, warning
-            buttons: ['Cancel', "Yes, Download it", 'No, maybe later.'],
-            defaultId: 1,
+          EventBus.emit('RoastMe', {
+            type: 'Info',
             title: 'Update Available: ' + serverVersion,
-            message: 'Do you want to Download the Update?',
+            message: 'Do you want to download this update?',
             detail: patchNotes,
-            cancelId: 0
-          };
-          let fileSavePath = await window.api.resolveEnvVariables('%LOCALAPPDATA%\\Temp\\EDHM_UI\\edhm-ui-v3-windows-x64.exe');
-          const platform = await window.api.getPlatform();
-          var download_url = '';  
-
-          window.api.ShowMessageBox(options).then(async result => {
-            if (result && result.response === 1) {
-
-              // 1. Check if the Game is already Running:
-              const fullPath = await window.api.detectProgram('EliteDangerous64.exe');
-              if (fullPath) {
-                console.log('Process found at:', fullPath);
-                EventBus.emit('RoastMe', {
-                  type: 'Accent', accent: 'error', background: 'warning',
-                  title: 'Can NOT update!', message: 'The game is Running<br>You need to close it to allow the update to be installed<br>Try again after closing the game.',
-                  width:'460px', autoHide: false
-                });
-                return;
-              } else {
-                if (platform === 'win32') {
-                  console.log('Running on Windows');
-                  //download_url = 'https://github.com/BlueMystical/EDHM_UI/releases/download/' + serverVersion + '/edhm-ui-v3-windows-x64.exe';
-                  download_url = 'https://github.com/BlueMystical/EDHM_UI/releases/latest/download/edhm-ui-v3-windows-x64.exe';
-
-                } else if (platform === 'linux') {
-                  console.log('Running on Linux');
-                  //download_url = 'https://github.com/BlueMystical/EDHM_UI/releases/download/' + serverVersion + '/edhm-ui-v3-linux-x64.zip';
-                  download_url = 'https://github.com/BlueMystical/EDHM_UI/releases/latest/download/edhm-ui-v3-linux-x64.zip';
-                  fileSavePath = '/tmp/EDHM_UI/edhm-ui-v3-linux-x64.zip';
-
-                } else {
-                  console.log(`Running on an unknown platform: ${platform}`);
-                  return;
-                }
-
-                //- Send the Command to start the Download
-                EventBus.emit('StartDownload', {  //<- Event Listen in 'NavBars.vue' -> DownloadAndInstallUpdate()
-                  url: download_url,
-                  save_to: fileSavePath,
-                  platform: platform
-                });
-
-              }
-              if (result && result.response === 2) {
-                EventBus.emit('RoastMe', { type: 'Info', message: 'There is an Update Available: ' + serverVersion, autoHide: false });
-              }
-            }
+            autoHide: false,
+            width: '650px',
+            actions: [
+              {
+                label: 'Yes, Download it',
+                class: 'btn-dark',
+                onClick: () => this.StartAvailableUpdateDownload(),
+              },
+              {
+                label: 'No, maybe later.',
+                class: 'btn-outline-dark',
+              },
+            ],
           });
         }
         else {

--- a/source_v3/src/MainWindow/App.vue
+++ b/source_v3/src/MainWindow/App.vue
@@ -241,10 +241,12 @@ export default {
           } else {
             this.settings.Version_HORIZ = edhmInstalled.version;
           }
+          // Refresh the monitor from the exact instance whose install just completed.
+          EventBus.emit('RefreshEDHMStatus', JSON.parse(JSON.stringify(NewInstance)));
           const Backup = await window.api.RestoreCurrentSettings();
           EventBus.emit('RoastMe', { type: 'Info', message: Backup });
           EventBus.emit('RoastMe', { type: 'Success', message: `EDHM ${edhmInstalled.version} Installed.` });
-        }        
+        }
 
         EventBus.emit('InitializeNavBars', JSON.parse(JSON.stringify(this.settings))); //<- Event Listened at NavBars.vue
         EventBus.emit('OnInitializeThemes', JSON.parse(JSON.stringify(this.settings)));//<- Event Listened at ThemeTab.vue

--- a/source_v3/src/MainWindow/App.vue
+++ b/source_v3/src/MainWindow/App.vue
@@ -808,12 +808,12 @@ export default {
             actions: [
               {
                 label: 'Yes, Download it',
-                class: 'btn-dark',
+                class: 'btn-success',
                 onClick: () => this.StartAvailableUpdateDownload(),
               },
               {
                 label: 'No, maybe later.',
-                class: 'btn-outline-dark',
+                class: 'btn-danger',
               },
             ],
           });

--- a/source_v3/src/MainWindow/Components/Notifications.vue
+++ b/source_v3/src/MainWindow/Components/Notifications.vue
@@ -353,7 +353,7 @@ export default {
   border: 1px solid rgba(0, 0, 0, 0.25);
   border-radius: 0.25rem;
   background-color: rgba(255, 255, 255, 0.2);
-  scrollbar-color: #fd7e14 rgba(12, 41, 49, 0.65);
+  scrollbar-color: #6f7cff rgba(12, 35, 58, 0.72);
   scrollbar-width: thin;
 }
 
@@ -362,18 +362,18 @@ export default {
 }
 
 .toast-detail::-webkit-scrollbar-track {
-  background: rgba(12, 41, 49, 0.65);
+  background: rgba(12, 35, 58, 0.72);
   border-radius: 0.25rem;
 }
 
 .toast-detail::-webkit-scrollbar-thumb {
-  background-color: #fd7e14;
-  border: 2px solid rgba(12, 41, 49, 0.65);
+  background-color: #6f7cff;
+  border: 2px solid rgba(12, 35, 58, 0.72);
   border-radius: 0.5rem;
 }
 
 .toast-detail::-webkit-scrollbar-thumb:hover {
-  background-color: #ffad5c;
+  background-color: #a78bfa;
 }
 
 .toast-detail::-webkit-scrollbar-button {

--- a/source_v3/src/MainWindow/Components/Notifications.vue
+++ b/source_v3/src/MainWindow/Components/Notifications.vue
@@ -353,6 +353,31 @@ export default {
   border: 1px solid rgba(0, 0, 0, 0.25);
   border-radius: 0.25rem;
   background-color: rgba(255, 255, 255, 0.2);
+  scrollbar-color: #fd7e14 rgba(12, 41, 49, 0.65);
+  scrollbar-width: thin;
+}
+
+.toast-detail::-webkit-scrollbar {
+  width: 12px;
+}
+
+.toast-detail::-webkit-scrollbar-track {
+  background: rgba(12, 41, 49, 0.65);
+  border-radius: 0.25rem;
+}
+
+.toast-detail::-webkit-scrollbar-thumb {
+  background-color: #fd7e14;
+  border: 2px solid rgba(12, 41, 49, 0.65);
+  border-radius: 0.5rem;
+}
+
+.toast-detail::-webkit-scrollbar-thumb:hover {
+  background-color: #ffad5c;
+}
+
+.toast-detail::-webkit-scrollbar-button {
+  display: none;
 }
 
 .custom-toast {

--- a/source_v3/src/MainWindow/Components/Notifications.vue
+++ b/source_v3/src/MainWindow/Components/Notifications.vue
@@ -59,7 +59,18 @@
             aria-atomic="true" v-on:click="toastClicked('Info')">
             <div class="d-flex align-items-center" style="height: 100%;">
                 <i class="bi bi-info-circle" style="font-size: 64px; margin-left:10px; margin-right: 4px;"></i>
-                <div class="toast-body text-black" v-html="toasts.Info.message"></div>
+                <div class="toast-body text-black">
+                    <h5 v-if="toasts.Info.title">{{ toasts.Info.title }}</h5>
+                    <div v-html="toasts.Info.message"></div>
+                    <div v-if="toasts.Info.detail" class="toast-detail mt-2" @click.stop>{{ toasts.Info.detail }}</div>
+                    <div v-if="toasts.Info.actions.length" class="toast-actions mt-3 d-flex gap-2" @click.stop>
+                        <button v-for="(action, index) in toasts.Info.actions" :key="index" type="button"
+                            :class="['btn', 'btn-sm', action.class || 'btn-outline-dark']"
+                            @click.stop="toastActionClicked('Info', action)">
+                            {{ action.label }}
+                        </button>
+                    </div>
+                </div>
                 <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
             </div>
         </div>
@@ -91,7 +102,7 @@ export default {
                 Error:      { title: '', message: '' },
                 Success:    { title: '', message: '' },
                 Warning:    { title: '', message: '' },
-                Info:       { title: '', message: '' }, 
+                Info:       { title: '', message: '', detail: '', actions: [] },
                 Accent:     { title: '', message: '' },
                 ErrMsg:     { title: '', message: '', stack: '' },
             },
@@ -104,6 +115,8 @@ export default {
                type: 'Info',            //<- Info, Success, Warning, Error, Accent
                title: '',               //<- [Optional] Title of the Toast
                message: '',             //<- Message of the Toast, accepts HTML tags
+               detail: '',              //<- [Optional] Plain-text detail displayed below the message
+               actions: [],             //<- [Optional] Buttons: { label, class, onClick }
                stack: '',               //<- [Optional] Only if 'type=Error', Stack Trace for Errors
                autoHide: true,          //<- [Optional] Toast hides automatically after a delay
                delay: 3000,             //<- [Optional] Auto-hide delay in milliseconds, 1s=1000ms, 1m=60000ms
@@ -116,6 +129,8 @@ export default {
                 type = 'Info',
                 title = '',
                 message = '',
+                detail = '',
+                actions = [],
                 stack,
                 autoHide = true,
                 delay = 5000, //<- 5 seconds default
@@ -129,6 +144,8 @@ export default {
             if (this.toasts[toastType]) {
                 this.toasts[toastType].title = title;
                 this.toasts[toastType].message = message;
+                this.toasts[toastType].detail = detail;
+                this.toasts[toastType].actions = Array.isArray(actions) ? actions : [];
                 if (stack) this.toasts[toastType].stack = stack;
 
                 const toast = document.getElementById(`liveToast-${toastType}`);
@@ -273,6 +290,17 @@ export default {
             // You can perform additional actions here when a toast is clicked
         },
 
+        async toastActionClicked(toastType, action) {
+            this.closeToast(toastType);
+            if (typeof action?.onClick === 'function') {
+                try {
+                    await action.onClick();
+                } catch (error) {
+                    EventBus.emit('ShowError', error);
+                }
+            }
+        },
+
         copyToClipboard(msg){
             window.api.copyToClipboard(msg);
         }
@@ -314,6 +342,17 @@ export default {
   padding: 10px;
   border-radius: 5px;
   overflow-x: auto;
+}
+
+.toast-detail {
+  width: 100%;
+  max-height: 45vh;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  padding: 0.5rem;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+  border-radius: 0.25rem;
+  background-color: rgba(255, 255, 255, 0.2);
 }
 
 .custom-toast {

--- a/source_v3/src/MainWindow/Components/Notifications.vue
+++ b/source_v3/src/MainWindow/Components/Notifications.vue
@@ -75,6 +75,28 @@
             </div>
         </div>
 
+        <!-- Dedicated Info-styled update prompt. It cannot be replaced by ordinary Info notifications. -->
+        <div id="liveToast-UpdateInfo" class="toast align-items-center bg-info border-0" role="alert"
+            aria-live="assertive" aria-atomic="true" v-on:click="toastClicked('UpdateInfo')">
+            <div class="d-flex align-items-center" style="height: 100%;">
+                <i class="bi bi-info-circle" style="font-size: 64px; margin-left:10px; margin-right: 4px;"></i>
+                <div class="toast-body text-black">
+                    <h5 v-if="toasts.UpdateInfo.title">{{ toasts.UpdateInfo.title }}</h5>
+                    <div v-html="toasts.UpdateInfo.message"></div>
+                    <div v-if="toasts.UpdateInfo.detail" class="toast-detail mt-2" @click.stop>{{ toasts.UpdateInfo.detail }}</div>
+                    <div v-if="toasts.UpdateInfo.actions.length" class="toast-actions mt-3 d-flex gap-2" @click.stop>
+                        <button v-for="(action, index) in toasts.UpdateInfo.actions" :key="index" type="button"
+                            :class="['btn', 'btn-sm', action.class || 'btn-outline-dark']"
+                            @click.stop="toastActionClicked('UpdateInfo', action)">
+                            {{ action.label }}
+                        </button>
+                    </div>
+                </div>
+                <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast"
+                    aria-label="Close"></button>
+            </div>
+        </div>
+
         <!-- Accent Type Toast Notification -->
         <div id="liveToast-Accent" class="toast custom-toast align-items-start text-bg-primary border-0" role="alert" aria-live="assertive" 
             aria-atomic="true"  v-on:click="toastClicked('Accent')">
@@ -103,6 +125,7 @@ export default {
                 Success:    { title: '', message: '' },
                 Warning:    { title: '', message: '' },
                 Info:       { title: '', message: '', detail: '', actions: [] },
+                UpdateInfo: { title: '', message: '', detail: '', actions: [] },
                 Accent:     { title: '', message: '' },
                 ErrMsg:     { title: '', message: '', stack: '' },
             },
@@ -112,7 +135,7 @@ export default {
         /** Displays a Colored Toast Notification at Bottom Right corner of the Window
          * @param data Configuration Object: 
           { 
-               type: 'Info',            //<- Info, Success, Warning, Error, Accent
+               type: 'Info',            //<- Info, UpdateInfo, Success, Warning, Error, Accent
                title: '',               //<- [Optional] Title of the Toast
                message: '',             //<- Message of the Toast, accepts HTML tags
                detail: '',              //<- [Optional] Plain-text detail displayed below the message

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -1238,6 +1238,7 @@ export default {
     EventBus.on('ThemeClicked', this.LoadTheme);
     EventBus.on('ShowSpinner', this.showHideSpinner);
     EventBus.on('modUpdated', this.OnModUpdated);
+    EventBus.on('RefreshEDHMStatus', this.RefreshEDHMStatus);
     EventBus.on('OnApplyTheme', this.applyTheme);
     EventBus.on('ApplyGivenTheme', this.ApplyGivenTheme);
     EventBus.on('StartDownload', this.DownloadAndInstallUpdate);
@@ -1255,6 +1256,7 @@ export default {
     EventBus.off('ThemeClicked', this.LoadTheme);
     EventBus.off('ShowSpinner', this.showHideSpinner);
     EventBus.off('modUpdated', this.OnModUpdated);
+    EventBus.off('RefreshEDHMStatus', this.RefreshEDHMStatus);
     EventBus.off('OnApplyTheme', this.applyTheme);
     EventBus.off('StartDownload', this.DownloadAndInstallUpdate);
     EventBus.off('OnGlobalSettingsLoaded', this.OnGlobalSettingsLoaded);

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -354,6 +354,14 @@ export default {
       }
     },
 
+    ShowEDHMNotInstalledToast() {
+      EventBus.emit('RoastMe', {
+        type: 'Error',
+        title: 'EDHM Status',
+        message: 'EDHM is not installed.<br>Please select Install EDHM from the main menu.',
+      });
+    },
+
     async ToggleEDHM() {
       try {
         const ActiveInstance = await window.api.getActiveInstance();
@@ -362,11 +370,7 @@ export default {
         this.edhmStatusConflict = result?.conflict === true;
 
         if (!result?.changed && result?.state === 'not_installed') {
-          EventBus.emit('RoastMe', {
-            type: 'Error',
-            title: 'EDHM Status',
-            message: 'EDHM is not installed.<br>Please select Install EDHM from the main menu.',
-          });
+          this.ShowEDHMNotInstalledToast();
           return false;
         }
 
@@ -484,17 +488,30 @@ export default {
         console.log('Apply Theme ignored while another theme operation is still running.');
         return false;
       }
-      if (!this.themeTemplate?.credits?.theme) {
-        EventBus.emit('ShowError', new Error('Select a theme and wait for it to finish loading before applying it.'));
-        return false;
-      }
 
       this.isApplying = true;
       this.showSpinner = true;
       try {
-        console.log('0. Applying Theme:', this.themeTemplate.credits.theme);
-
         this.ActiveInstance = await window.api.getActiveInstance();
+        const edhmStatus = await this.RefreshEDHMStatus(this.ActiveInstance);
+        if (!edhmStatus) {
+          EventBus.emit('RoastMe', {
+            type: 'Error',
+            title: 'EDHM Status',
+            message: 'Unable to verify whether EDHM is installed.',
+          });
+          return false;
+        }
+        if (edhmStatus.state === 'not_installed') {
+          this.ShowEDHMNotInstalledToast();
+          return false;
+        }
+        if (!this.themeTemplate?.credits?.theme) {
+          EventBus.emit('ShowError', new Error('Select a theme and wait for it to finish loading before applying it.'));
+          return false;
+        }
+
+        console.log('0. Applying Theme:', this.themeTemplate.credits.theme);
         console.log('1. ActiveInstance:', this.ActiveInstance.instance);
 
         const GamePath = await window.api.joinPath(this.ActiveInstance.path, 'EDHM-ini');

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -293,6 +293,7 @@ export default {
       gameMenuItems: [],
       edhmStatusState: 'not_installed',
       edhmStatusConflict: false,
+      initialEDHMStatusChecked: false,
 
       showProgressBar: false,
       progressValue: 0,
@@ -362,6 +363,35 @@ export default {
       });
     },
 
+    ShowInitialEDHMStatusToast(status) {
+      if (this.initialEDHMStatusChecked) return;
+      this.initialEDHMStatusChecked = true;
+
+      if (!status) {
+        EventBus.emit('RoastMe', {
+          type: 'Error',
+          title: 'EDHM Status',
+          message: 'Unable to verify the EDHM installation status.',
+        });
+      } else if (status.conflict) {
+        EventBus.emit('RoastMe', {
+          type: 'Error',
+          title: 'EDHM Installation Needs Attention',
+          message: 'One or more required EDHM DLL files are missing or duplicated.<br>' +
+            'Reinstall EDHM or correct the DLL filenames before using Enable/Disable.',
+        });
+      } else if (status.state === 'not_installed') {
+        this.ShowEDHMNotInstalledToast();
+      } else if (status.state === 'disabled') {
+        EventBus.emit('RoastMe', {
+          type: 'Warning',
+          title: 'EDHM Disabled',
+          message: 'EDHM is currently disabled.<br>' +
+            'Enable EDHM before starting Elite Dangerous to load custom themes in game.',
+        });
+      }
+    },
+
     async ToggleEDHM() {
       try {
         const ActiveInstance = await window.api.getActiveInstance();
@@ -403,7 +433,8 @@ export default {
         this.modVersion = settings.Version_ODYSS;
         this.ActiveInstance = await window.api.getActiveInstance();
         this.selectedGame = this.ActiveInstance.instance;
-        await this.RefreshEDHMStatus(this.ActiveInstance);
+        const initialEDHMStatus = await this.RefreshEDHMStatus(this.ActiveInstance);
+        this.ShowInitialEDHMStatusToast(initialEDHMStatus);
         this.showFavorites = settings.FavToogle;
         this.activeTab = ref('themes');
 

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -29,8 +29,8 @@
               <option value="mnuExit">Exit App</option>
             </select>
           </div>
-          <span id="lblEDHMStatus" :class="['navbar-text', 'mx-3', 'text-nowrap', edhmStatusClass]">
-            {{ edhmStatusMessage }}
+          <span id="lblEDHMStatus" class="navbar-text mx-3 text-nowrap">
+            Status: <span :class="edhmStatusClass">{{ edhmStatusMessage }}</span>
           </span>
         </div>
 
@@ -320,11 +320,11 @@ export default {
     edhmStatusMessage() {
       switch (this.edhmStatusState) {
         case 'ready':
-          return 'Status: Ready';
+          return 'Ready';
         case 'disabled':
-          return 'Status: Disabled';
+          return 'Disabled';
         default:
-          return 'Status: Not Installed, please select Install EDHM from the main menu.';
+          return 'Not Installed, please select Install EDHM from the main menu.';
       }
     },
     edhmStatusClass() {

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -596,7 +596,20 @@ export default {
         console.log('DONE! - Theme Applied:', this.themeTemplate.credits.theme);
         EventBus.emit('OnThemeApplied',         JSON.parse(JSON.stringify(template))); //<- Listen on App.vue
         EventBus.emit('CurretSettingsUpdated',  JSON.parse(JSON.stringify(template))); //<- Listen on ThemeTab.vue
-        EventBus.emit('RoastMe', { type: 'Success', message: `<b>Theme: '${template.credits.theme}' Applied!` });
+        if (edhmStatus.state === 'disabled') {
+          EventBus.emit('RoastMe', {
+            type: 'Warning',
+            title: 'EDHM Disabled',
+            message: `<b>Theme: '${template.credits.theme}' Applied!</b><br>` +
+              'EDHM is currently disabled, so the game cannot load this theme. ' +
+              'Enable EDHM before your next game launch to see the changes.',
+          });
+        } else {
+          EventBus.emit('RoastMe', {
+            type: 'Success',
+            message: `<b>Theme: '${template.credits.theme}' Applied!`,
+          });
+        }
         return true;
 
       } catch (error) {

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -6,7 +6,7 @@
       <div class="container-fluid d-flex justify-content-between align-items-center">
 
         <!-- Main Menu -->
-        <div class="nav-item">
+        <div class="nav-item d-flex align-items-center">
           <div class="input-group mb-3 ">
             <select ref="mainMenuSelect" id="mainMenuSelect" class="form-select main-menu-style"
               @change="MainMenu_Click($event.target.value)">
@@ -29,6 +29,9 @@
               <option value="mnuExit">Exit App</option>
             </select>
           </div>
+          <span id="lblEDHMStatus" :class="['navbar-text', 'mx-3', 'text-nowrap', edhmStatusClass]">
+            {{ edhmStatusMessage }}
+          </span>
         </div>
 
         <!-- Navbar for Buttons on the right side -->
@@ -288,6 +291,8 @@ export default {
       modVersion: '',
       selectedGame: '',
       gameMenuItems: [],
+      edhmStatusState: 'not_installed',
+      edhmStatusConflict: false,
 
       showProgressBar: false,
       progressValue: 0,
@@ -311,7 +316,91 @@ export default {
     UserSettingsTab,
     GlobalSettingsTab
   },
+  computed: {
+    edhmStatusMessage() {
+      switch (this.edhmStatusState) {
+        case 'ready':
+          return 'Status: Ready';
+        case 'disabled':
+          return 'Status: Disabled';
+        default:
+          return 'Status: Not Installed, please select Install EDHM from the main menu.';
+      }
+    },
+    edhmStatusClass() {
+      switch (this.edhmStatusState) {
+        case 'ready':
+          return 'edhm-status-ready';
+        case 'disabled':
+          return 'edhm-status-disabled';
+        default:
+          return 'edhm-status-not-installed';
+      }
+    },
+  },
   methods: {
+
+    async RefreshEDHMStatus(gameInstance = this.ActiveInstance) {
+      try {
+        const status = await window.api.GetEDHMStatus(JSON.parse(JSON.stringify(gameInstance || {})));
+        this.edhmStatusState = status?.state || 'not_installed';
+        this.edhmStatusConflict = status?.conflict === true;
+        return status;
+      } catch (error) {
+        console.error('Unable to determine EDHM status:', error);
+        this.edhmStatusState = 'not_installed';
+        this.edhmStatusConflict = false;
+        return null;
+      }
+    },
+
+    async ShowEDHMStatusDialog(type, message, detail = '') {
+      return window.api.ShowMessageBox({
+        type,
+        buttons: ['OK'],
+        defaultId: 0,
+        cancelId: 0,
+        noLink: true,
+        title: 'EDHM Status',
+        message,
+        detail,
+      });
+    },
+
+    async ToggleEDHM() {
+      try {
+        const ActiveInstance = await window.api.getActiveInstance();
+        const result = await window.api.ToggleEDHMmod(JSON.parse(JSON.stringify(ActiveInstance)));
+        this.edhmStatusState = result?.state || 'not_installed';
+        this.edhmStatusConflict = result?.conflict === true;
+
+        if (!result?.changed && result?.state === 'not_installed') {
+          await this.ShowEDHMStatusDialog(
+            'warning',
+            'EDHM is not installed.',
+            'Please select Install EDHM from the main menu.'
+          );
+          return false;
+        }
+
+        const enabled = result?.state === 'ready';
+        await this.ShowEDHMStatusDialog(
+          'info',
+          enabled ? 'EDHM Enabled!' : 'EDHM Disabled!',
+          'The change will take effect the next time Elite Dangerous starts.'
+        );
+        return true;
+      } catch (error) {
+        await this.RefreshEDHMStatus();
+        const detail = error?.message || String(error);
+        await this.ShowEDHMStatusDialog(
+          'error',
+          'Unable to enable or disable EDHM.',
+          detail
+        );
+        return false;
+      }
+    },
 
     async OnInitialize(settings) {
       try {
@@ -322,6 +411,7 @@ export default {
         this.modVersion = settings.Version_ODYSS;
         this.ActiveInstance = await window.api.getActiveInstance();
         this.selectedGame = this.ActiveInstance.instance;
+        await this.RefreshEDHMStatus(this.ActiveInstance);
         this.showFavorites = settings.FavToogle;
         this.activeTab = ref('themes');
 
@@ -580,12 +670,10 @@ export default {
           if (_ret) {
             EventBus.emit('RoastMe', { type: 'Success', message: 'EDHM Un-Installed!' });
           }
+          await this.RefreshEDHMStatus(ActiveInstance);
         }
         if (value === 'mnuDisableMod') {
-          const _ret = await window.api.DisableEDHMmod(JSON.parse(JSON.stringify(ActiveInstance)));
-          if (_ret) {
-            EventBus.emit('RoastMe', { type: 'Success', message: 'EDHM Disabled!' });
-          }
+          await this.ToggleEDHM();
         }
         if (value === 'mnuGoToDiscord') {
           await window.api.openUrlInBrowser('https://discord.gg/ZaRt6bCXvj');
@@ -992,6 +1080,7 @@ export default {
       this.programSettings = data;
       //console.log('programSettings: ', programSettings);
       this.modVersion = data.Version_ODYSS;
+      this.RefreshEDHMStatus();
     },
     OnXmlChanged(data) {
       console.log('XML Changed:', data);
@@ -1244,6 +1333,18 @@ body {
 .main-menu-style {
   border: 2px solid orange;
   /* Add an orange border */
+}
+
+.edhm-status-ready {
+  color: #28a745 !important;
+}
+
+.edhm-status-disabled {
+  color: #dc3545 !important;
+}
+
+.edhm-status-not-installed {
+  color: #fd7e14 !important;
 }
 
 .middle-div {

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -376,7 +376,7 @@ export default {
 
         const enabled = result?.state === 'ready';
         EventBus.emit('RoastMe', {
-          type: 'Success',
+          type: enabled ? 'Success' : 'Error',
           title: 'EDHM Status',
           message: `${enabled ? 'EDHM Enabled!' : 'EDHM Disabled!'}<br>` +
             'The change will take effect the next time Elite Dangerous starts.',

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -76,7 +76,8 @@
               <i class="bi bi-star"></i>
             </button>
 
-            <button id="cmdApplyTheme" class="btn btn-apply-theme" @click="applyTheme">Apply Theme</button>
+            <button id="cmdApplyTheme" class="btn btn-apply-theme" :disabled="isApplying || isThemeLoading"
+              @click="applyTheme">Apply Theme</button>
 
             <!-- History Box -->
             <select class="form-select" id="cboHistoryBox" @change="OnHistoryBox_Click" v-model="selectedHistory"
@@ -265,6 +266,9 @@ export default {
       statusText: '',
       showFavorites: false,
       showSpinner: true,
+      isApplying: false,
+      isThemeLoading: false,
+      themeLoadRequestId: 0,
 
       programSettings: {},
       themeTemplate: {},
@@ -358,29 +362,56 @@ export default {
      * @param theme Data of selected Theme
      */
     async LoadTheme(theme) {
+      const requestId = ++this.themeLoadRequestId;
+      this.isThemeLoading = true;
       this.showSpinner = true;
       try {
         if (theme && theme.file) {
           const template = JSON.parse(JSON.stringify(theme.file));
           console.log('Loading Theme..', template.credits.theme);
+          let loadedTemplate;
 
           if (template.credits.theme === 'Current Settings') {
-            this.themeTemplate = await window.api.GetCurrentSettingsTheme(template.path);
-            this.currentSettingsPath = template.path;
+            loadedTemplate = await window.api.GetCurrentSettingsTheme(template.path);
           } else {
-            this.themeTemplate = await window.api.LoadTheme(template.path);
-            console.log('Loaded Theme:', this.themeTemplate);
-            this.themeTemplate.credits = theme.file.credits;
+            loadedTemplate = await window.api.LoadTheme(template.path);
+            loadedTemplate.credits = theme.file.credits;
           }
 
+          // A newer selection superseded this request while its file was loading.
+          if (requestId !== this.themeLoadRequestId) {
+            return false;
+          }
+
+          this.themeTemplate = loadedTemplate;
+          this.currentSettingsPath = template.credits.theme === 'Current Settings' ? template.path : '';
+          console.log('Loaded Theme:', this.themeTemplate);
           EventBus.emit('ThemeLoaded', JSON.parse(JSON.stringify(this.themeTemplate))); //<- this event will be heard on 'App.vue'
           this.statusText = 'Theme: ' + theme.name;
+          return true;
         }
+        return false;
       } catch (error) {
         EventBus.emit('ShowError', new Error(error.message + error.stack));
-      } finally { this.showSpinner = false; }
+        return false;
+      } finally {
+        if (requestId === this.themeLoadRequestId) {
+          this.isThemeLoading = false;
+          this.showSpinner = false;
+        }
+      }
     },
     async applyTheme() {
+      if (this.isApplying || this.isThemeLoading) {
+        console.log('Apply Theme ignored while another theme operation is still running.');
+        return false;
+      }
+      if (!this.themeTemplate?.credits?.theme) {
+        EventBus.emit('ShowError', new Error('Select a theme and wait for it to finish loading before applying it.'));
+        return false;
+      }
+
+      this.isApplying = true;
       this.showSpinner = true;
       try {
         console.log('0. Applying Theme:', this.themeTemplate.credits.theme);
@@ -429,6 +460,7 @@ export default {
             console.log(counter + ' ' + counterName + ' added!');
           } catch (error) {
             console.log('ERROR @SettingsHelper.applyTheme().applySettings():', error);
+            throw error;
           }
         }
 
@@ -450,39 +482,52 @@ export default {
         const updatedInis = await window.api.ApplyTemplateValuesToIni(template, defaultINIs);
         console.log('7. Applying Changes to the INIs...', updatedInis);
         console.log('8. Saving the INI files..');
-        const _ret = await window.api.SaveThemeINIs(GamePath, updatedInis);
+        const inisSaved = await window.api.SaveThemeINIs(GamePath, updatedInis);
+        if (!inisSaved) {
+          throw new Error('One or more theme INI files could not be saved.');
+        }
 
-        const _curSettsSAved = await window.api.SaveTheme(template);
-        console.log('9. Saving Current Settings: ', _curSettsSAved);
+        // ThemeSettings.json is the in-game reload signal, so write it only
+        // after every INI has been saved successfully.
+        const currentSettingsSaved = await window.api.SaveTheme(template);
+        console.log('9. Saving Current Settings: ', currentSettingsSaved);
+        if (!currentSettingsSaved) {
+          throw new Error('Theme INIs were saved, but ThemeSettings.json could not be updated.');
+        }
 
         console.log('10. Writing Theme in History..');
         await this.History_AddSettings(template);
-        
-        if (_ret) {
-          console.log('DONE! - Theme Applied:', this.themeTemplate.credits.theme);
-          EventBus.emit('OnThemeApplied',         JSON.parse(JSON.stringify(template))); //<- Listen on App.vue
-          EventBus.emit('CurretSettingsUpdated',  JSON.parse(JSON.stringify(template))); //<- Listen on ThemeTab.vue
-          EventBus.emit('RoastMe', { type: 'Success', message: `<b>Theme: '${template.credits.theme}' Applied!` }); //</b><small>Press <b>F11</b> in game to refresh the colors.</small>
-        }
-        setTimeout(() => {
-          this.showSpinner = false;
-        }, 1500);
+
+        console.log('DONE! - Theme Applied:', this.themeTemplate.credits.theme);
+        EventBus.emit('OnThemeApplied',         JSON.parse(JSON.stringify(template))); //<- Listen on App.vue
+        EventBus.emit('CurretSettingsUpdated',  JSON.parse(JSON.stringify(template))); //<- Listen on ThemeTab.vue
+        EventBus.emit('RoastMe', { type: 'Success', message: `<b>Theme: '${template.credits.theme}' Applied!` });
+        return true;
 
       } catch (error) {
-        this.showSpinner = false;
         console.log(error.message); // Check if the error message is defined 
         console.log(error.stack); // Check the stack trace
         EventBus.emit('ShowError', error);
+        return false;
+      } finally {
+        this.isApplying = false;
+        this.showSpinner = false;
       }
     },
     async ApplyGivenTheme(event) {
       try {
         console.log('Applying Given Theme:', event);
-        this.themeTemplate = event;
-        this.applyTheme();
+        if (event?.file) {
+          const loaded = await this.LoadTheme(event);
+          if (!loaded) return false;
+        } else {
+          this.themeTemplate = JSON.parse(JSON.stringify(event));
+        }
+        return await this.applyTheme();
       } catch (error) {
         EventBus.emit('ShowError', error);
-      } 
+        return false;
+      }
     },
     async LoadCurrentSettings() {
       try {

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -354,19 +354,6 @@ export default {
       }
     },
 
-    async ShowEDHMStatusDialog(type, message, detail = '') {
-      return window.api.ShowMessageBox({
-        type,
-        buttons: ['OK'],
-        defaultId: 0,
-        cancelId: 0,
-        noLink: true,
-        title: 'EDHM Status',
-        message,
-        detail,
-      });
-    },
-
     async ToggleEDHM() {
       try {
         const ActiveInstance = await window.api.getActiveInstance();
@@ -375,29 +362,30 @@ export default {
         this.edhmStatusConflict = result?.conflict === true;
 
         if (!result?.changed && result?.state === 'not_installed') {
-          await this.ShowEDHMStatusDialog(
-            'warning',
-            'EDHM is not installed.',
-            'Please select Install EDHM from the main menu.'
-          );
+          EventBus.emit('RoastMe', {
+            type: 'Error',
+            title: 'EDHM Status',
+            message: 'EDHM is not installed.<br>Please select Install EDHM from the main menu.',
+          });
           return false;
         }
 
         const enabled = result?.state === 'ready';
-        await this.ShowEDHMStatusDialog(
-          'info',
-          enabled ? 'EDHM Enabled!' : 'EDHM Disabled!',
-          'The change will take effect the next time Elite Dangerous starts.'
-        );
+        EventBus.emit('RoastMe', {
+          type: 'Success',
+          title: 'EDHM Status',
+          message: `${enabled ? 'EDHM Enabled!' : 'EDHM Disabled!'}<br>` +
+            'The change will take effect the next time Elite Dangerous starts.',
+        });
         return true;
       } catch (error) {
         await this.RefreshEDHMStatus();
         const detail = error?.message || String(error);
-        await this.ShowEDHMStatusDialog(
-          'error',
-          'Unable to enable or disable EDHM.',
-          detail
-        );
+        EventBus.emit('RoastMe', {
+          type: 'Error',
+          title: 'EDHM Status',
+          message: `Unable to enable or disable EDHM.<br>${detail}`,
+        });
         return false;
       }
     },

--- a/source_v3/src/MainWindow/NavBars.vue
+++ b/source_v3/src/MainWindow/NavBars.vue
@@ -627,7 +627,15 @@ export default {
         console.log('DONE! - Theme Applied:', this.themeTemplate.credits.theme);
         EventBus.emit('OnThemeApplied',         JSON.parse(JSON.stringify(template))); //<- Listen on App.vue
         EventBus.emit('CurretSettingsUpdated',  JSON.parse(JSON.stringify(template))); //<- Listen on ThemeTab.vue
-        if (edhmStatus.state === 'disabled') {
+        if (edhmStatus.conflict) {
+          EventBus.emit('RoastMe', {
+            type: 'Warning',
+            title: 'EDHM Installation Needs Attention',
+            message: `<b>Theme: '${template.credits.theme}' Applied!</b><br>` +
+              'One or more required EDHM DLL files are missing or duplicated, so the game may not load this theme. ' +
+              'Reinstall EDHM or correct the DLL filenames before your next game launch.',
+          });
+        } else if (edhmStatus.state === 'disabled') {
           EventBus.emit('RoastMe', {
             type: 'Warning',
             title: 'EDHM Disabled',

--- a/source_v3/src/MainWindow/ThemeTab.vue
+++ b/source_v3/src/MainWindow/ThemeTab.vue
@@ -198,7 +198,7 @@ export default {
     /** When Fired, Selects and Loads a given Theme   * 
      * @param theme We only need the id (index in the list) -> { id: 0 }
      */
-    OnSelectTheme(theme) {
+    OnSelectTheme(theme, loadTheme = true) {
       try {
         //console.log(this.selectedTheme);
         if (theme && !isEmpty(theme)) {
@@ -219,7 +219,10 @@ export default {
                     selectedElement.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
                   }
                 });
-                EventBus.emit('ThemeClicked', JSON.parse(JSON.stringify(selectedItem))); //<- this event will be heard in 'MainNavBars.vue'
+                if (loadTheme) {
+                  EventBus.emit('ThemeClicked', JSON.parse(JSON.stringify(selectedItem))); //<- this event will be heard in 'MainNavBars.vue'
+                }
+                return selectedItem;
               }
             }
             else {
@@ -237,14 +240,14 @@ export default {
      * @param theme_name Name of the Theme to be applied     */
     FindAndApplyTheme(theme_name) {
       console.log('FindAndApplyTheme: ', theme_name);
-      if (this.themes && this.themes.length > 0) {        
+      if (this.themes && this.themes.length > 0) {
         const index = this.themes.findIndex(obj => obj.file.name === theme_name);
         if (index !== -1) {
           console.log('Theme Found: ', this.themes[index].name);
-          this.OnSelectTheme({ id: index });
-          EventBus.emit('OnApplyTheme', null); //<- this event will be heard in 'NavBars.vue'  
+          const selectedItem = this.OnSelectTheme({ id: index }, false);
+          EventBus.emit('ApplyGivenTheme', JSON.parse(JSON.stringify(selectedItem))); //<- NavBars loads it before applying
         } else {
-            console.log(`Object with name ${tName} not found.`);
+            console.log(`Object with name ${theme_name} not found.`);
         }
       }
     },
@@ -329,7 +332,7 @@ export default {
         if (this.selectedTheme) {
           switch (action) {
             case 'ApplyTheme':
-              EventBus.emit('OnApplyTheme', null); //<- this event will be heard in 'MainNavBars.vue'
+              EventBus.emit('ApplyGivenTheme', JSON.parse(JSON.stringify(this.selectedTheme))); //<- NavBars loads it before applying
               break;
 
             case 'ThemePreview':

--- a/source_v3/src/preload.js
+++ b/source_v3/src/preload.js
@@ -151,6 +151,8 @@ contextBridge.exposeInMainWorld('api', {
   installEDHMmod: (gameInstance) => ipcRenderer.invoke('installEDHMmod', gameInstance),
   CheckEDHMinstalled: (gamePath) => ipcRenderer.invoke('CheckEDHMinstalled', gamePath),
   UninstallEDHMmod: (gameInstance) => ipcRenderer.invoke('UninstallEDHMmod', gameInstance),
+  GetEDHMStatus: (gameInstance) => ipcRenderer.invoke('GetEDHMStatus', gameInstance),
+  ToggleEDHMmod: (gameInstance) => ipcRenderer.invoke('ToggleEDHMmod', gameInstance),
   DisableEDHMmod: (gameInstance) => ipcRenderer.invoke('DisableEDHMmod', gameInstance),
   DoHotFix: async () => ipcRenderer.invoke('DoHotFix'),
 


### PR DESCRIPTION
## Summary

This PR improves the reliability of theme application, implements functional EDHM enable/disable controls, and brings status, error, warning, and update feedback into the application's existing toast notification system.

## Why these changes were needed

Theme application could appear successful even when not every INI write had completed or succeeded. The in-game reload signal could therefore be written before all settings were safely on disk, and overlapping theme selection/application operations could use incomplete or stale data. This explains cases where users had to click **Apply Theme** more than once before the game reflected the change.

The existing Enable/Disable command did not provide a reliable way to control whether EDHM loaded with the game. Users also had no persistent indication of whether the required proxy DLLs were enabled, disabled, incomplete, duplicated, or absent.

Several workflows used native system dialogs or transient messages that were visually inconsistent with the rest of the application. The update prompt additionally needed to remain actionable without being displaced by unrelated Info notifications.

## What changed

### Theme application reliability

- Load only the theme INI files that are actually available for the selected game version.
- Await and verify every INI save instead of treating partially completed writes as success.
- Write `ThemeSettings.json`, which acts as the in-game reload signal, only after all INI files have been saved successfully.
- Prevent overlapping theme load/apply operations and ignore stale asynchronous theme-selection results.
- Ensure context-menu and shipyard theme application loads the requested theme before applying it.
- Block Apply Theme when EDHM is not installed.
- Preserve theme application while EDHM is disabled or its DLL state needs attention, but report the result with a yellow warning explaining that the game may not load the changes.

### EDHM enable/disable and status monitoring

- Enable and disable EDHM by renaming both proxy DLLs as a matching pair:
  - `d3d11.dll`
  - `d3dcompiler_47.dll`
- Use filesystem rename operations that work on Windows and Linux/Wine/Proton paths.
- Recover mixed states where only one DLL has the `.disabled` suffix.
- Detect missing and duplicate filenames and warn the user at launch.
- Roll back already completed renames if the second DLL rename fails, avoiding a newly introduced mixed state.
- Detect a running `EliteDangerous64.exe` process and provide a useful locked-file/game-running error.
- Remove stale disabled copies during installation and include disabled filenames during uninstall cleanup.
- Refresh status immediately after installation, instance changes, and Enable/Disable actions.
- Persist a newly selected game instance before reinitializing components, ensuring status checks and Apply Theme target the correct installation.
- Add a top-level status monitor with neutral `Status:` text and colored Ready, Disabled, and Not Installed values.

### Toast and update experience

- Route EDHM install, enable/disable, apply, warning, and error feedback through the application's existing toast system.
- Use green for success, red for failures/disabled state, and yellow for warnings.
- Replace the native update confirmation dialog with an Info-styled actionable toast containing the dynamic version and changelog.
- Add green download and red decline buttons while preserving the existing update download and running-game safety flow.
- Give the update prompt a dedicated Info-styled toast slot so ordinary Info or maintenance messages cannot overwrite it.
- Add a scrollable changelog area with cool navy, indigo, and lavender scrollbar colors.

## User impact

Users should now receive a dependable result from a single Apply Theme action, see the actual EDHM state for the selected game installation, safely enable or disable both required DLLs together, and receive consistent in-app feedback that explains when applied settings cannot yet appear in game.

## Validation

- `npm run package` completed successfully with Electron Forge/Vite.
- Exercised ready, disabled, mixed, missing, and duplicate DLL state handling with a targeted status matrix.
- Simulated failure of the second DLL rename and verified rollback of the first rename.
- Verified the selected instance is saved before component/status reinitialization.
- Verified the update prompt uses its dedicated toast identity.
- Ran `git diff --check` successfully.
- Rebuilt `local_build` and verified SHA-256 matches for the executable, `app.asar`, Chrome resource packages, and the English locale package.

The package process continues to emit the repository's existing Vite CJS API and Node `DEP0174` deprecation warnings; no packaging errors were produced.
