### PR TITLE
Add Frontier OAuth fleet sync to the Shipyard

### DIFF
--- a/Linux Users.md
+++ b/Linux Users.md
@@ -1,0 +1,92 @@
+# Linux Users
+
+EDHM_UI runs as a native Linux x64 Electron application and can manage an Elite Dangerous installation running through Proton or Wine. This guide is limited to installing, configuring, building, and troubleshooting EDHM_UI, including Frontier fleet authorization.
+
+## Install the released build
+
+1. Download both `edhm-ui-v3-linux-x64.zip` and `linux_installer.sh` from the [latest EDHM_UI release](https://github.com/BlueMystical/EDHM_UI/releases/latest).
+2. Place both files in the same directory.
+3. Open a terminal in that directory and run:
+
+   ```bash
+   chmod +x linux_installer.sh
+   ./linux_installer.sh
+   ```
+
+The installer extracts EDHM_UI to `~/.local/share/EDHM-UI-V3`, makes the application executable, creates desktop and application-menu shortcuts, and registers EDHM-UI to handle Frontier's `edhm://frontier-auth` callback. The `unzip`, `pgrep`, and `pkill` commands must be available.
+
+Do not run EDHM_UI or its installer as root. Running it as another user changes its settings and credential-storage locations.
+
+## Configure EDHM-UI paths
+
+Use the EDHM_UI Settings menu to select the Elite Dangerous installation and Player Journal directories. A path selected by the user always takes priority.
+
+For a new Linux configuration, the Player Journal fallback is the standard Steam/Proton location:
+
+```text
+~/.local/share/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved Games/Frontier Developments/Elite Dangerous
+```
+
+Steam libraries on other drives and installations managed by Lutris, Heroic, or a custom Wine prefix may store the journal elsewhere. Select the actual `Elite Dangerous` journal directory in Settings; EDHM_UI preserves custom paths instead of replacing them with the fallback.
+
+## Frontier account authorization
+
+The Shipyard can import the Commander's fleet from Frontier. Open the Shipyard and select **Connect Frontier** to begin.
+
+Linux requires an installed and unlocked system credential store, such as GNOME Keyring/libsecret or KDE Wallet. EDHM_UI encrypts the Frontier tokens through Electron's secure storage and deliberately refuses the insecure `basic_text` fallback. If secure storage is unavailable, unlock or configure the desktop keyring and restart EDHM_UI.
+
+Authorization works as follows:
+
+1. EDHM_UI registers itself as the handler for the `edhm://` protocol.
+2. The default browser opens Frontier's authorization page.
+3. After approval, Frontier returns the browser to `edhm://frontier-auth`.
+4. The desktop opens the callback in the running EDHM-UI instance, which validates the request, securely stores the tokens, and downloads the fleet.
+
+No localhost web server or self-signed certificate is used. The browser may ask for confirmation before opening an external application; approve opening EDHM-UI. There should be no unsafe-certificate warning or Advanced bypass.
+
+If the authorization page is closed before approval, select **Cancel Connection** in the Shipyard to clear the pending request before trying again.
+
+Frontier access and refresh tokens never enter the renderer or `Shipyard_v3.json`. They are encrypted in the Electron user-data directory, normally under `~/.config/EDHM-UI-V3`. Disconnecting the Frontier account removes the stored authorization without deleting Shipyard themes.
+
+## Build from source
+
+Build on a Linux x64 system with Git, a current Node.js LTS release, npm, `jq`, and the normal Electron build dependencies for the distribution.
+
+```bash
+git clone https://github.com/BlueMystical/EDHM_UI.git
+cd EDHM_UI/source_v3
+npm ci
+npm test
+npm start
+```
+
+After verifying the application locally, create the release ZIP with:
+
+```bash
+chmod +x linux-build.sh
+./linux-build.sh
+```
+
+The script asks for the application version and runs the Electron Forge ZIP maker. The resulting archive is written below:
+
+```text
+source_v3/out/make/zip/linux/x64/
+```
+
+Rename the release archive to `edhm-ui-v3-linux-x64.zip` before distributing it with `linux_installer.sh`.
+
+## Sandbox packaging
+
+The published ZIP installation is not sandboxed. Flatpak or other sandboxed packages need explicit access to the system browser, the desktop keyring, custom-protocol activation, the selected Steam or Wine prefix, the Player Journal directory, and the Elite Dangerous installation. A package that does not grant those permissions may launch successfully but still be unable to authorize Frontier or manage EDHM files.
+
+## Troubleshooting checklist
+
+- Launch EDHM_UI as the desktop user, not as root.
+- Confirm the configured game and Player Journal directories in Settings.
+- Confirm the system keyring is installed, unlocked, and available to Electron.
+- Allow the browser to open EDHM-UI when it receives the `edhm://frontier-auth` callback.
+- If the browser reports that no application can handle `edhm://`, rerun `linux_installer.sh` as the desktop user to restore the protocol registration.
+- For Frontier errors, disconnect the account, reconnect it, and complete the browser flow again.
+- If a selected directory is inside another Steam library or Wine prefix, confirm that the EDHM_UI process can read and write that location.
+
+Implementation and security details are documented in [Frontier OAuth and Shipyard Fleet Sync](source_v3/FRONTIER_OAUTH.md).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 # EDHM_UI
 
-[![License: GPL-3.0+](https://img.shields.io/badge/license-GPL--3.0%2B-blue.svg)](https://raw.githubusercontent.com/BlueMystical/EDHM_UI/main/license.txt)
-[![Latest Release](https://img.shields.io/github/v/release/BlueMystical/EDHM_UI)](https://github.com/BlueMystical/EDHM_UI/releases)
-[![Downloads](https://img.shields.io/github/downloads/BlueMystical/EDHM_UI/latest/total)](https://github.com/BlueMystical/EDHM_UI/releases)
-[![Issues](https://img.shields.io/github/issues/BlueMystical/EDHM_UI)](https://github.com/BlueMystical/EDHM_UI/issues)
-[![Discord](https://img.shields.io/discord/773552741632180224?color=899AF9)](https://discord.gg/ZaRt6bCXvj)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](license.txt)
+[![GitHub release](https://img.shields.io/github/v/release/BlueMystical/EDHM_UI?include_prereleases&sort=semver)](https://github.com/BlueMystical/EDHM_UI/releases)
+[![GitHub downloads](https://img.shields.io/github/downloads/BlueMystical/EDHM_UI/total)](https://github.com/BlueMystical/EDHM_UI/releases)
+[![GitHub issues](https://img.shields.io/github/issues/BlueMystical/EDHM_UI)](https://github.com/BlueMystical/EDHM_UI/issues)
+[![Built for EDHM](https://img.shields.io/badge/Built%20for-EDHM-1f6feb)](https://github.com/psychicEgg/EDHM)
+[![Runtime: Electron](static/badges/runtime-electron.svg)](source_v3/package.json)
+[![Windows x64](https://img.shields.io/badge/Windows-x64-0078D4?logo=windows11&logoColor=white)](#installation)
+[![Linux](https://img.shields.io/badge/Linux-Proton%20%2F%20Wine-FCC624?logo=linux&logoColor=black)](Linux%20Users.md)
+[![Discord](https://img.shields.io/discord/773552741632180224?color=5865F2&logo=discord&logoColor=white)](https://discord.gg/ZaRt6bCXvj)
 
 User Interface for Elite Dangerous HUD Mod (EDHM)
 
@@ -13,8 +17,7 @@ User Interface for Elite Dangerous HUD Mod (EDHM)
 ## What is EDHM_UI?
 
 EDHM_UI is the user interface for the Elite Dangerous mod [EDHM](https://github.com/psychicEgg/EDHM).
-The purpose of EDHM is to allow players of the game to customize their HUD Colors in many ways.
-This is estrictly a graphical mod, we dont change any in-game mechanics or things that FDev charges for.
+EDHM lets players customize their HUD colors and other graphical elements. It does not change game mechanics or paid game content.
 
 Current features include:
 
@@ -22,27 +25,30 @@ Current features include:
   graphical interface.
 * Bundled with the latest EDHM version - no need to install EDHM separately.
 * Bundled with lots of pre-made, community-contributed themes.
-* Fully compatible with both Horizons and Odyssey!
+* Compatible with both Horizons and Odyssey.
 * Translated to 6 languages: EN, RU, DE, FR, IT, PT.
 
 ## Requirements
 
-EDHM_UI requires Microsoft .NET Framework version 4.52 or newer. If you are on
-Windows 10, you may already have it. If you don't have it installed yet, you.
-can get it [here](https://dotnet.microsoft.com/download/dotnet-framework/net452).
+EDHM_UI v3 is an Electron application for Windows x64 and Linux x64. Elite Dangerous and the EDHM core mod are required to see themes in game.
+
+Linux users running Elite Dangerous through Proton or Wine should read [Linux Users](Linux%20Users.md) before installing or building the application.
 
 ## Installation
 
-* Download the latest `EDHM_UI_Setup.msi` file from the [releases page](https://github.com/BlueMystical/EDHM_UI/releases/latest).
+### Windows
+
+* Download `edhm-ui-v3-windows-x64.exe` from the [latest release](https://github.com/BlueMystical/EDHM_UI/releases/latest).
 * Run the installer and follow the on-screen prompts.
-* Double-click on the EDHM_UI desktop icon.
-* Profit!
+* Launch EDHM_UI from the desktop shortcut.
+
+### Linux
+
+See [Linux Users](Linux%20Users.md) for installation, building from source, Proton/Wine paths, system-keyring requirements, and Frontier account authorization.
 
 ## First-Run Setup
 
-The first time EDHM_UI runs, it will prompt you for the Elite Dangerous game
-folder. This determines where the EDHM core mod will be installed. The location
-varies depending on which version of ED you have installed. Simply click the Green Button and do as the Assistant says.
+The first time EDHM_UI runs, it will prompt you for the Elite Dangerous game folder. This determines where the EDHM core mod will be installed. The location varies depending on the selected game installation. Follow the setup assistant to select the correct folder.
 
 
 ## Further reading
@@ -50,6 +56,7 @@ varies depending on which version of ED you have installed. Simply click the Gre
 * [EDHM Website](https://bluemystical.github.io/edhm-api/)
 * [EDHM (GitHub)](https://github.com/psychicEgg/EDHM)
 * [EDHM (Reddit)](https://www.reddit.com/r/EliteDangerous/comments/iu4mbj/elite_dangerous_hud_mod_edhm_custom_huds_without/)
+* [Linux installation, build, and Frontier authorization](Linux%20Users.md)
 
 ## Support
 

--- a/source_v3/FRONTIER_OAUTH.md
+++ b/source_v3/FRONTIER_OAUTH.md
@@ -1,0 +1,80 @@
+# Frontier OAuth and Shipyard Fleet Sync
+
+## Registered application
+
+- Client ID: `ec3e9295-0633-462a-955c-8f41e3b8d7b4`
+- Redirect URI: `edhm://frontier-auth`
+- Scopes: `auth capi`
+- Shared key: not used
+
+EDHM-UI is a public desktop client. It uses OAuth 2.0 Authorization Code with PKCE, so a client secret is neither required nor safe to distribute with the application.
+
+## User flow
+
+1. The user opens the Shipyard and selects **Connect Frontier**.
+2. EDHM-UI creates a random PKCE verifier, challenge, and OAuth state value.
+3. EDHM-UI registers itself as the operating-system handler for the `edhm://` protocol.
+4. The system browser opens Frontier's authorization page.
+5. Frontier redirects the browser to `edhm://frontier-auth` after approval. The operating system sends that URL to the running EDHM-UI instance.
+6. EDHM-UI validates the returned state and exchanges the authorization code and PKCE verifier for access and refresh tokens.
+7. EDHM-UI requests `/profile`, normalizes the owned fleet, and merges it into `Shipyard_v3.json` while retaining themes, custom images, and unmatched Journal/V2 records.
+
+The callback wait times out after five minutes. If the browser is closed before approval, the user can select **Cancel Connection** to clear the pending request and try again immediately. No localhost web server, listening port, TLS certificate, or certificate exception is required. Depending on browser settings, the user may be asked to confirm that the browser is allowed to open EDHM-UI.
+
+## Token security
+
+- Tokens remain in the Electron main process and are never returned through preload IPC.
+- Authorization callback URLs are removed from renderer arguments and are not logged by EDHM-UI.
+- Tokens are encrypted using Electron `safeStorage` and stored as `frontier-auth-token.dat` under Electron's `app.getPath('userData')` directory.
+- The encrypted file is written with owner-only permissions where the operating system supports them.
+- Linux `basic_text` storage is rejected. Users must have an available, unlocked system keyring.
+- There is no plaintext fallback.
+- Disconnecting removes the token file but intentionally retains the user's Shipyard configuration.
+
+User-facing Linux setup and troubleshooting are documented in [Linux Users](../Linux%20Users.md#frontier-account-authorization).
+
+## Frontier requests
+
+- Authorization: `https://auth.frontierstore.net/auth`
+- Token exchange and refresh: `https://auth.frontierstore.net/token`
+- Live fleet: `https://companion.orerve.net/profile?language=en`
+- Legacy fleet: `https://legacy-companion.orerve.net/profile?language=en`
+- User-Agent: `EDCD-EDHMUI-<app version>`
+
+The active game instance selects the Live or Legacy CAPI host. Fleet requests occur only after login or an explicit **Refresh Fleet** action. Successful refreshes are limited to one per minute, following Frontier's CAPI guidance.
+
+Access tokens are refreshed shortly before expiration. Refresh-token failure caused by expiration or revoked authorization removes the unusable local authorization and asks the user to connect again. Frontier currently requires users to reauthorize after the refresh-token authorization window expires.
+
+## Shipyard merge behavior
+
+Frontier's `ships` property may be an array or an object keyed by ship ID. Both forms are supported. Each normalized ship receives a stable `frontier_id` and `record_id`, allowing multiple ships of the same model to be customized independently.
+
+On refresh:
+
+- Existing theme assignments and custom images are preserved.
+- Frontier-sourced ships no longer present in the fleet are removed.
+- Journal and V2-imported records not represented by Frontier are retained.
+- Unknown future ship models remain visible using the default ship image.
+- The raw CAPI profile, loadout modules, access token, and refresh token are not written to `Shipyard_v3.json`.
+
+### Ship identity and journal matching
+
+Frontier's numeric ship `id` and the Player Journal `Loadout.ShipID` identify the same owned ship and are the primary match key. This keeps multiple ships of the same model separate even when they share a custom name or displayed identifier. Renaming a ship or changing its identifier updates the saved display data without losing its assigned theme or custom image.
+
+Older Shipyard records that do not contain an owned-ship ID are migrated using a normalized model, custom name (`name` or legacy `custom_name`), and displayed identifier match. Once matched, they receive the numeric ID so later journal events cannot create a duplicate. A reused numeric ID associated with a different ship model is treated as a new ship and does not inherit the sold ship's customization.
+
+## Development checks
+
+From `source_v3`:
+
+```text
+npm test
+npm run package
+```
+
+The unit tests cover custom-protocol callback recognition, array and ID-keyed Frontier responses, ship-model normalization, duplicate-current-ship prevention, customization preservation, journal rename handling, legacy-record migration, same-model ship separation, sold-ship removal, and retention of local-only Shipyard records.
+
+## References
+
+- [EDCD Frontier OAuth notes](https://github.com/EDCD/FDevIDs/blob/master/Frontier%20API/FrontierDevelopments-oAuth2-notes.md)
+- [EDCD Frontier CAPI endpoints](https://github.com/EDCD/FDevIDs/blob/master/Frontier%20API/FrontierDevelopments-CAPI-endpoints.md)

--- a/source_v3/forge.config.js
+++ b/source_v3/forge.config.js
@@ -3,6 +3,12 @@ const { FusesPlugin } = require('@electron-forge/plugin-fuses');
 const { FuseV1Options, FuseVersion } = require('@electron/fuses');
 const fs = require('node:fs');
 const path = require('path');
+const platformArgument = process.argv.find((argument) => argument.startsWith('--platform='));
+const platformArgumentIndex = process.argv.indexOf('--platform');
+const requestedPlatform = platformArgument
+  ? platformArgument.slice('--platform='.length)
+  : (platformArgumentIndex >= 0 ? process.argv[platformArgumentIndex + 1] : null);
+const isLinuxBuild = (requestedPlatform || process.platform) === 'linux';
 
 function reveal(r) { return atob(r).split("").map((r => String.fromCharCode(r.charCodeAt(0) - 3))).join("").split("").reverse().join("") };
 function safeInclude(n) { return fs.existsSync(n) ? n : null }
@@ -19,18 +25,25 @@ module.exports = {
       'public',
       'out/renderer/settings_window'
     ],
-    icon: path.join(__dirname, 'src', 'images', 'Icon_v3_a0.ico'), //'public/images/Icon_v3_a0.ico'
     appCategoryType: 'public.app-category.developer-tools',
-    win32metadata: {
-      FileDescription: 'Mod for Elite Dangerous to customize the HUD of any ship.',
-      ProductName: 'EDHM-UI-V3',
-      CompanyName: 'Blue Mystic',
-      "requested-execution-level": "highestAvailable"
-    }
+    ...(isLinuxBuild ? {
+      name: 'edhm-ui-v3',
+      executableName: 'edhm-ui-v3',
+      icon: path.join(__dirname, 'public', 'images', 'icon.png')
+    } : {
+      icon: path.join(__dirname, 'src', 'images', 'Icon_v3_a0.ico'),
+      win32metadata: {
+        FileDescription: 'EDHM-UI-V3',
+        ProductName: 'EDHM-UI-V3',
+        CompanyName: 'Blue Mystic',
+        "requested-execution-level": "highestAvailable"
+      }
+    })
   },
   makers: [
     {
       name: '@electron-forge/maker-squirrel',
+      platforms: ['win32'],
       config: {
         name: 'EDHM-UI-V3',
         authors: 'Blue Mystic',
@@ -54,7 +67,8 @@ module.exports = {
       }
     },
     {
-      name: '@electron-forge/maker-zip'
+      name: '@electron-forge/maker-zip',
+      platforms: ['win32', 'linux']
     }
   ],
   plugins: [

--- a/source_v3/linux-build.sh
+++ b/source_v3/linux-build.sh
@@ -38,13 +38,10 @@ echo "Version updated to: $NEW_VERSION in '$JSON_FILE'"
 
 # Build the app using npm
 echo "Building the app..."
-npm run make -- --arch="x64" --targets="@electron-forge/maker-zip"
-
-# Check the exit code of the npm command
-if [ $? -eq 0 ]; then
+if npm run make -- --arch="x64" --targets="@electron-forge/maker-zip"; then
   echo "App build completed successfully."
+  exit 0
 else
   echo "Error during app build."
+  exit 1
 fi
-
-exit 0

--- a/source_v3/package-lock.json
+++ b/source_v3/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "edhm-ui-v3",
-  "version": "3.0.38",
+  "version": "3.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "edhm-ui-v3",
-      "version": "3.0.38",
+      "version": "3.0.68",
       "license": "MIT",
       "dependencies": {
         "bootstrap": "^5.3.3",

--- a/source_v3/package.json
+++ b/source_v3/package.json
@@ -10,6 +10,7 @@
   "main": ".vite/build/main.js",
   "scripts": {
     "start": "electron-forge start",
+    "test": "node --test test/*.test.mjs",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish"

--- a/source_v3/public/linux_installer.sh
+++ b/source_v3/public/linux_installer.sh
@@ -33,7 +33,7 @@ fi
 
 # Create the target directory and unzip
 unzip "$ZIP_FILE"
-UNZIPPED_DIR=$(find "." -maxdepth 1 -type d -name "edhm-ui-v3-linux-x64")
+UNZIPPED_DIR=$(find "." -maxdepth 1 -type d -iname "edhm-ui-v3-linux-x64" -print -quit)
 if [ -z "$UNZIPPED_DIR" ]; then
     echo "Error: Unzipped directory not found."
     exit 1
@@ -43,6 +43,12 @@ rm -r "$TARGET_DIR"
 
 mv "$UNZIPPED_DIR" "$TARGET_DIR"
 
+# Validate the case-sensitive executable name before changing permissions.
+if [ ! -f "$TARGET_DIR/$APP_EXE" ]; then
+    echo "Error: Application executable '$APP_EXE' was not found in the package."
+    exit 1
+fi
+
 # Make the executable file executable
 chmod +x "$TARGET_DIR/$APP_EXE"
 
@@ -51,18 +57,27 @@ DESKTOP_CONTENT="
 [Desktop Entry]
 Encoding=UTF-8
 Name=EDHM-UI-V3
-Exec=$TARGET_DIR/$APP_EXE
+Exec=$TARGET_DIR/$APP_EXE %u
 Icon=$ICON_PATH
 Terminal=false
 Type=Application
 Comment=Mod for Elite Dangerous to customize the HUD of any ship.
 StartupNotify=true
 Categories=Utility;
+MimeType=x-scheme-handler/edhm;
 "
 echo "$DESKTOP_CONTENT" > "$DESKTOP_FILE"
 chmod +x "$DESKTOP_FILE"
 echo "$DESKTOP_CONTENT" > "$APPLICATIONS_FILE"
 chmod +x "$APPLICATIONS_FILE"
+
+# Register the Frontier OAuth callback protocol for this desktop user.
+if command -v xdg-mime >/dev/null 2>&1; then
+    xdg-mime default "$(basename "$APPLICATIONS_FILE")" x-scheme-handler/edhm
+fi
+if command -v update-desktop-database >/dev/null 2>&1; then
+    update-desktop-database "$(dirname "$APPLICATIONS_FILE")"
+fi
 
 # DEBUG: Pause before running the application
 if [ $DEBUG -eq 1 ]; then

--- a/source_v3/readme.md
+++ b/source_v3/readme.md
@@ -81,18 +81,8 @@ To use this project, you can do the following:
 - Build the Project
 
 ## COMPILING ON LINUX
-- Setup a Virtual Machine with Linux Debian 11 or above, i use Oracle VirtualBox
-- Open a Terminal on ```~/Documents/edhm-ui-v3```
-- Copy any Source code modified files from the real PC into the VM
-- Copy the 'ODYSS_EDHM-v[number].zip' and Themes Files
-- Test the program:   npm start
-- Run:
-```
-./linux-build.sh
-```
-- Input the new Version
-- Copy ```..\EDHM_UI\source_v3\out\make\zip\linux\x64\edhm-ui-v3-linux-x64-3.0.68.zip``` into ..```..\EDHM_UI\source_v3\out\Installer\Build```
-- Rename the file as edhm-ui-v3-linux-x64.zip
+
+See [Linux Users](../Linux%20Users.md#build-from-source) for the current Linux dependencies, test procedure, build command, output location, and Frontier authorization requirements.
 
 ## PUBLISHING
 - Make a new Release on GitHub

--- a/source_v3/readme.md
+++ b/source_v3/readme.md
@@ -13,6 +13,10 @@ App is made with Electron Forge Vite-Vue and Bootstrap
 * [Electron Vue](https://github.com/SimulatedGREG/electron-vue)
 * [Bootstrap](https://getbootstrap.com)
 
+## Frontier Fleet Integration
+
+The Shipyard can import a Commander's owned ships from Frontier CAPI using OAuth 2.0 Authorization Code with PKCE. See [FRONTIER_OAUTH.md](FRONTIER_OAUTH.md) for the implementation, security, storage, and testing details.
+
 ## Requeriments (For Development):
 - NODE:   [Download](https://nodejs.org/en/download/prebuilt-installer)
 - NPM:    Comes with Node, check the [Documentation](https://docs.npmjs.com/cli/v11/commands/npm)

--- a/source_v3/src/Helpers/FileHelper.js
+++ b/source_v3/src/Helpers/FileHelper.js
@@ -1080,33 +1080,16 @@ function terminateProgram_OLD(exeName, callback) {
   }
 }
 
-/** Open the File Explorer showing a selected Folder
- * @param {*} filePath Folder to select */
-function openPathInExplorer(filePath) {
-  const normalizedPath = resolveEnvVariables(
-    path.normalize(filePath)); // Normalize path to avoid issues
-
-  let command;
-
-  if (os.platform() === 'win32') {
-    command = `start "" "${normalizedPath}"`;
-  } else if (os.platform() === 'darwin') {
-    command = `open "${normalizedPath}"`;
-  } else {
-    command = `xdg-open "${normalizedPath}"`;
+/** Open a file or directory using the operating system's default handler.
+ * @param {string} filePath File or directory to open. */
+async function openPathInExplorer(filePath) {
+  const normalizedPath = path.resolve(resolveEnvVariables(path.normalize(filePath)));
+  const errorMessage = await shell.openPath(normalizedPath);
+  if (errorMessage) {
+    throw new Error(`Unable to open ${normalizedPath}: ${errorMessage}`);
   }
-
-  exec(command, (error, stdout, stderr) => {
-    if (error) {
-      console.error(`Error opening path: ${error.message}`);
-      return;
-    }
-    if (stderr) {
-      console.error(`stderr: ${stderr}`);
-      return;
-    }
-    console.log(`Path opened successfully: ${stdout}`);
-  });
+  console.log(`Path opened successfully: ${normalizedPath}`);
+  return normalizedPath;
 };
 
 /** Open the file using the default program.
@@ -1557,7 +1540,7 @@ ipcMain.handle('run-program', async (event, filePath, args = []) => {
 
 ipcMain.handle('openPathInExplorer', async (event, filePath) => {
   try {
-    const result = openPathInExplorer(filePath);
+    const result = await openPathInExplorer(filePath);
     return result;
   } catch (error) {
     throw new Error(error.message + error.stack);

--- a/source_v3/src/Helpers/FrontierApi.js
+++ b/source_v3/src/Helpers/FrontierApi.js
@@ -1,0 +1,367 @@
+import { app, safeStorage, shell } from 'electron';
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
+import path from 'node:path';
+import { chmod, mkdir, readFile, rename, unlink, writeFile } from 'node:fs/promises';
+import {
+  FRONTIER_REDIRECT_URI,
+  parseFrontierAuthCallback,
+} from './FrontierOAuth.mjs';
+
+const FRONTIER_CLIENT_ID = 'ec3e9295-0633-462a-955c-8f41e3b8d7b4';
+const FRONTIER_AUTHORIZE_URL = 'https://auth.frontierstore.net/auth';
+const FRONTIER_TOKEN_URL = 'https://auth.frontierstore.net/token';
+const FRONTIER_PROFILE_URLS = {
+  live: 'https://companion.orerve.net/profile?language=en',
+  legacy: 'https://legacy-companion.orerve.net/profile?language=en',
+};
+const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
+const REQUEST_TIMEOUT_MS = 30 * 1000;
+const MIN_PROFILE_INTERVAL_MS = 60 * 1000;
+
+const base64Url = (buffer) => buffer
+  .toString('base64')
+  .replace(/\+/g, '-')
+  .replace(/\//g, '_')
+  .replace(/=+$/g, '');
+
+const constantTimeEqual = (left, right) => {
+  const leftBuffer = Buffer.from(String(left || ''), 'utf8');
+  const rightBuffer = Buffer.from(String(right || ''), 'utf8');
+  return leftBuffer.length === rightBuffer.length && timingSafeEqual(leftBuffer, rightBuffer);
+};
+
+class FrontierApi {
+  constructor() {
+    this.tokenFilePath = path.join(app.getPath('userData'), 'frontier-auth-token.dat');
+    this.authorizationPromise = null;
+    this.authorizationCallback = null;
+  }
+
+  get userAgent() {
+    return `EDCD-EDHMUI-${app.getVersion()}`;
+  }
+
+  assertPrivateStorageAvailable() {
+    if (!safeStorage.isEncryptionAvailable()) {
+      throw new Error(
+        'Secure token storage is unavailable. Configure your operating system credential store and try again.'
+      );
+    }
+    if (process.platform === 'linux' && safeStorage.getSelectedStorageBackend() === 'basic_text') {
+      throw new Error(
+        'A secure Linux credential store is unavailable. Install and unlock a supported keyring before connecting Frontier.'
+      );
+    }
+  }
+
+  async loadTokens() {
+    try {
+      const encrypted = await readFile(this.tokenFilePath, 'utf8');
+      this.assertPrivateStorageAvailable();
+      const decrypted = safeStorage.decryptString(Buffer.from(encrypted.trim(), 'base64'));
+      const tokens = JSON.parse(decrypted);
+      if (!tokens?.accessToken && !tokens?.refreshToken) return null;
+      return tokens;
+    } catch (error) {
+      if (error?.code === 'ENOENT') return null;
+      throw new Error(`Unable to read the securely stored Frontier authorization: ${error.message}`);
+    }
+  }
+
+  async saveTokens(tokens) {
+    this.assertPrivateStorageAvailable();
+    const directory = path.dirname(this.tokenFilePath);
+    const temporaryPath = `${this.tokenFilePath}.tmp`;
+    await mkdir(directory, { recursive: true });
+    const encrypted = safeStorage.encryptString(JSON.stringify(tokens)).toString('base64');
+    await writeFile(temporaryPath, encrypted, { encoding: 'utf8', mode: 0o600 });
+    await rename(temporaryPath, this.tokenFilePath);
+    try {
+      await chmod(this.tokenFilePath, 0o600);
+    } catch (error) {
+      if (process.platform !== 'win32') throw error;
+    }
+  }
+
+  async clearTokens() {
+    try {
+      await unlink(this.tokenFilePath);
+    } catch (error) {
+      if (error?.code !== 'ENOENT') throw error;
+    }
+  }
+
+  async getStatus() {
+    const tokens = await this.loadTokens();
+    return {
+      authorized: Boolean(tokens?.accessToken || tokens?.refreshToken),
+      commanderName: tokens?.commanderName || '',
+      expiresAt: tokens?.expiresAt || null,
+      lastSyncAt: tokens?.lastSyncAt || null,
+      shipCount: Number(tokens?.shipCount || 0),
+    };
+  }
+
+  async requestJson(url, options, purpose) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+    try {
+      const response = await fetch(url, { ...options, signal: controller.signal });
+      const responseText = await response.text();
+      let data = null;
+      if (responseText) {
+        try {
+          data = JSON.parse(responseText);
+        } catch {
+          data = responseText;
+        }
+      }
+      if (!response.ok) {
+        const detail = typeof data === 'string'
+          ? data.slice(0, 300)
+          : data?.message || data?.error_description || data?.error || response.statusText;
+        const error = new Error(`${purpose} failed (${response.status}): ${detail}`);
+        error.status = response.status;
+        throw error;
+      }
+      return data;
+    } catch (error) {
+      if (error?.name === 'AbortError') {
+        throw new Error(`${purpose} timed out. Please check your connection and try again.`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  normalizeTokenResponse(response, previousTokens = {}) {
+    if (!response?.access_token) {
+      throw new Error('Frontier did not return an access token.');
+    }
+    const now = Date.now();
+    return {
+      accessToken: response.access_token,
+      refreshToken: response.refresh_token || previousTokens.refreshToken || '',
+      tokenType: response.token_type || previousTokens.tokenType || 'Bearer',
+      expiresAt: now + (Number(response.expires_in || 0) * 1000),
+      authorizedAt: previousTokens.authorizedAt || now,
+      commanderName: previousTokens.commanderName || '',
+      lastSyncAt: previousTokens.lastSyncAt || null,
+      shipCount: Number(previousTokens.shipCount || 0),
+    };
+  }
+
+  async exchangeAuthorizationCode(code, verifier, redirectUri) {
+    const body = new URLSearchParams({
+      redirect_uri: redirectUri,
+      code,
+      grant_type: 'authorization_code',
+      code_verifier: verifier,
+      client_id: FRONTIER_CLIENT_ID,
+    });
+    const response = await this.requestJson(FRONTIER_TOKEN_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+        'User-Agent': this.userAgent,
+      },
+      body: body.toString(),
+    }, 'Frontier token exchange');
+    const tokens = this.normalizeTokenResponse(response);
+    await this.saveTokens(tokens);
+    return tokens;
+  }
+
+  async refreshAccessToken(previousTokens) {
+    if (!previousTokens?.refreshToken) {
+      throw new Error('Frontier authorization has expired. Connect your Frontier account again.');
+    }
+    const body = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: FRONTIER_CLIENT_ID,
+      refresh_token: previousTokens.refreshToken,
+    });
+    let response;
+    try {
+      response = await this.requestJson(FRONTIER_TOKEN_URL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+          'User-Agent': this.userAgent,
+        },
+        body: body.toString(),
+      }, 'Frontier token refresh');
+    } catch (error) {
+      if (error?.status === 400 || error?.status === 401) {
+        await this.clearTokens();
+        throw new Error('Frontier authorization expired or was revoked. Connect your Frontier account again.');
+      }
+      throw error;
+    }
+    const tokens = this.normalizeTokenResponse(response, previousTokens);
+    await this.saveTokens(tokens);
+    return tokens;
+  }
+
+  async ensureAccessToken(forceRefresh = false) {
+    const tokens = await this.loadTokens();
+    if (!tokens) {
+      throw new Error('Connect your Frontier account before refreshing the fleet.');
+    }
+    if (!forceRefresh && tokens.accessToken && Number(tokens.expiresAt) > Date.now() + 60_000) {
+      return tokens;
+    }
+    return this.refreshAccessToken(tokens);
+  }
+
+  createAuthorizationCallback(expectedState) {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        if (this.authorizationCallback?.expectedState === expectedState) {
+          this.authorizationCallback = null;
+        }
+        reject(new Error('Frontier authorization timed out. Please try again.'));
+      }, AUTH_TIMEOUT_MS);
+
+      this.authorizationCallback = {
+        expectedState,
+        timeoutId,
+        resolve,
+        reject,
+      };
+    });
+  }
+
+  clearAuthorizationCallback(expectedState) {
+    if (!this.authorizationCallback || this.authorizationCallback.expectedState !== expectedState) return;
+    clearTimeout(this.authorizationCallback.timeoutId);
+    this.authorizationCallback = null;
+  }
+
+  cancelAuthorization() {
+    const pending = this.authorizationCallback;
+    if (!pending) return false;
+
+    clearTimeout(pending.timeoutId);
+    this.authorizationCallback = null;
+    pending.reject(new Error('Frontier authorization was cancelled.'));
+    return true;
+  }
+
+  handleAuthorizationCallback(callbackValue) {
+    const callback = parseFrontierAuthCallback(callbackValue);
+    if (!callback) return false;
+
+    const pending = this.authorizationCallback;
+    if (!pending) {
+      console.warn('Received a Frontier authorization callback with no authorization in progress.');
+      return false;
+    }
+
+    clearTimeout(pending.timeoutId);
+    this.authorizationCallback = null;
+
+    if (!constantTimeEqual(callback.state, pending.expectedState)) {
+      pending.reject(new Error('Frontier authorization returned an invalid security state. Please try again.'));
+      return true;
+    }
+    if (callback.error) {
+      pending.reject(new Error(
+        `Frontier authorization was not granted: ${callback.errorDescription || callback.error}`
+      ));
+      return true;
+    }
+    if (!callback.code) {
+      pending.reject(new Error('Frontier did not return an authorization code.'));
+      return true;
+    }
+
+    pending.resolve(callback.code);
+    return true;
+  }
+
+  async authorize() {
+    if (this.authorizationPromise) return this.authorizationPromise;
+    this.authorizationPromise = this.performAuthorization();
+    try {
+      return await this.authorizationPromise;
+    } finally {
+      this.authorizationPromise = null;
+    }
+  }
+
+  async performAuthorization() {
+    this.assertPrivateStorageAvailable();
+    const verifier = base64Url(randomBytes(32));
+    const challenge = base64Url(createHash('sha256').update(verifier, 'ascii').digest());
+    const state = base64Url(randomBytes(32));
+    const callback = this.createAuthorizationCallback(state);
+    // Cancellation can reject this while openExternal is still resolving.
+    // Awaiting the original promise below continues to propagate that error.
+    void callback.catch(() => {});
+
+    const authorizationUrl = new URL(FRONTIER_AUTHORIZE_URL);
+    authorizationUrl.search = new URLSearchParams({
+      audience: 'frontier',
+      scope: 'auth capi',
+      response_type: 'code',
+      client_id: FRONTIER_CLIENT_ID,
+      code_challenge: challenge,
+      code_challenge_method: 'S256',
+      state,
+      redirect_uri: FRONTIER_REDIRECT_URI,
+    }).toString();
+
+    try {
+      await shell.openExternal(authorizationUrl.toString());
+      const code = await callback;
+      await this.exchangeAuthorizationCode(code, verifier, FRONTIER_REDIRECT_URI);
+      return this.getStatus();
+    } finally {
+      this.clearAuthorizationCallback(state);
+    }
+  }
+
+  async fetchProfile(galaxy = 'live') {
+    const currentTokens = await this.loadTokens();
+    if (currentTokens?.lastSyncAt) {
+      const waitMs = MIN_PROFILE_INTERVAL_MS - (Date.now() - Number(currentTokens.lastSyncAt));
+      if (waitMs > 0) {
+        throw new Error(`Please wait ${Math.ceil(waitMs / 1000)} seconds before refreshing the Frontier fleet again.`);
+      }
+    }
+
+    const profileUrl = FRONTIER_PROFILE_URLS[galaxy] || FRONTIER_PROFILE_URLS.live;
+    let tokens = await this.ensureAccessToken();
+    const requestProfile = () => this.requestJson(profileUrl, {
+      method: 'GET',
+      headers: {
+        Authorization: `${tokens.tokenType || 'Bearer'} ${tokens.accessToken}`,
+        'User-Agent': this.userAgent,
+        Accept: 'application/json',
+      },
+    }, 'Frontier fleet request');
+
+    try {
+      return await requestProfile();
+    } catch (error) {
+      if (error?.status !== 401 && error?.status !== 422) throw error;
+      tokens = await this.ensureAccessToken(true);
+      return requestProfile();
+    }
+  }
+
+  async recordFleetSync(commanderName, shipCount) {
+    const tokens = await this.loadTokens();
+    if (!tokens) return;
+    await this.saveTokens({
+      ...tokens,
+      commanderName: commanderName || tokens.commanderName || '',
+      lastSyncAt: Date.now(),
+      shipCount: Number(shipCount || 0),
+    });
+  }
+}
+
+export default FrontierApi;

--- a/source_v3/src/Helpers/FrontierFleet.mjs
+++ b/source_v3/src/Helpers/FrontierFleet.mjs
@@ -1,0 +1,228 @@
+export const normalizeShipSymbol = (value) => String(value || '')
+  .trim()
+  .replace(/^\$shipname_/i, '')
+  .replace(/_name;?$/i, '')
+  .replace(/;$/g, '')
+  .toLowerCase()
+  .replace(/[^a-z0-9]/g, '');
+
+export const normalizeOwnedShipId = (value) => {
+  if (value === null || value === undefined) return null;
+  const normalized = String(value).trim();
+  return normalized === '' ? null : normalized;
+};
+
+const normalizeIdentityText = (value) => String(value ?? '').trim().toLowerCase();
+
+const getShipName = (ship) => {
+  if (typeof ship?.name === 'string') return ship.name;
+  if (typeof ship?.custom_name === 'string') return ship.custom_name;
+  return '';
+};
+
+const hasSameModel = (left, right) =>
+  normalizeShipSymbol(left?.kind_short) === normalizeShipSymbol(right?.kind_short);
+
+const hasSameLegacyIdentity = (left, right) =>
+  hasSameModel(left, right) &&
+  normalizeIdentityText(getShipName(left)) === normalizeIdentityText(getShipName(right)) &&
+  normalizeIdentityText(left?.plate) === normalizeIdentityText(right?.plate);
+
+const pickCustomization = (frontierShip, candidates) => {
+  const themed = candidates.find((ship) =>
+    ship?.theme && ship.theme !== 'Current Settings'
+  ) || candidates.find((ship) => ship?.theme);
+  const customImage = candidates.find((ship) =>
+    ship?.image && ship.image !== frontierShip.image
+  ) || candidates.find((ship) => ship?.image);
+
+  return {
+    theme: themed?.theme || frontierShip.theme,
+    image: customImage?.image || frontierShip.image,
+  };
+};
+
+export const normalizeFrontierShips = (profile, shipListData = []) => {
+  const shipsValue = profile?.ships;
+  const entries = Array.isArray(shipsValue)
+    ? shipsValue.map((ship, index) => [String(ship?.id ?? index), ship])
+    : Object.entries(shipsValue || {});
+
+  if (profile?.ship) {
+    const currentId = String(profile.ship.id ?? profile.commander?.currentShipId ?? 'current');
+    if (!entries.some(([key, ship]) => String(ship?.id ?? key) === currentId)) {
+      entries.push([currentId, profile.ship]);
+    }
+  }
+
+  return entries
+    .filter(([, ship]) => ship && typeof ship === 'object')
+    .map(([entryId, ship]) => {
+      const frontierId = normalizeOwnedShipId(ship.id ?? entryId);
+      const symbol = ship.name || ship.shipType || ship.ship;
+      const normalizedSymbol = normalizeShipSymbol(symbol);
+      const model = shipListData.find((candidate) =>
+        normalizeShipSymbol(candidate.ed_short) === normalizedSymbol ||
+        normalizeShipSymbol(candidate.ship_full_name) === normalizedSymbol
+      );
+      const kindShort = model?.ed_short?.toLowerCase() || String(symbol || 'unknown').toLowerCase();
+      const customName = typeof ship.shipName === 'string'
+        ? ship.shipName.trim()
+        : String(model?.ship_full_name || symbol || 'Unnamed Ship').trim();
+      return {
+        record_id: `frontier:${frontierId}`,
+        frontier_id: frontierId,
+        ship_id: model?.ship_id ?? `frontier-${frontierId}`,
+        kind_short: kindShort,
+        kind_full: model?.ship_full_name || String(symbol || 'Unknown Ship'),
+        name: customName,
+        plate: String(ship.shipID || '').trim(),
+        theme: 'Current Settings',
+        image: model ? `${model.ed_short.toLowerCase()}.jpg` : '@default.jpg',
+        source: 'frontier',
+      };
+    });
+};
+
+export const mergeFrontierShips = (frontierShips, existingShips = []) => {
+  const claimedIndexes = new Set();
+  const customizationCandidates = frontierShips.map(() => []);
+
+  // First correlate by the game-owned numeric ID. This remains reliable when
+  // the Commander renames a ship or changes its displayed identifier.
+  frontierShips.forEach((frontierShip, frontierIndex) => {
+    const frontierId = normalizeOwnedShipId(frontierShip.frontier_id);
+    if (!frontierId) return;
+
+    existingShips.forEach((existingShip, existingIndex) => {
+      if (claimedIndexes.has(existingIndex)) return;
+      if (normalizeOwnedShipId(existingShip.frontier_id) !== frontierId) return;
+
+      claimedIndexes.add(existingIndex);
+      // Frontier can reuse an ID after a ship is sold. Consume the stale
+      // record, but do not carry its customization to a different model.
+      if (hasSameModel(existingShip, frontierShip)) {
+        customizationCandidates[frontierIndex].push(existingShip);
+      }
+    });
+  });
+
+  // Migrate one legacy Journal/V2 record per otherwise-unmatched Frontier
+  // ship. Records with another stable ID must never be collapsed by name.
+  frontierShips.forEach((frontierShip, frontierIndex) => {
+    if (customizationCandidates[frontierIndex].length > 0) return;
+    const legacyIndex = existingShips.findIndex((existingShip, existingIndex) =>
+      !claimedIndexes.has(existingIndex) &&
+      !normalizeOwnedShipId(existingShip.frontier_id) &&
+      hasSameLegacyIdentity(existingShip, frontierShip)
+    );
+    if (legacyIndex < 0) return;
+
+    claimedIndexes.add(legacyIndex);
+    customizationCandidates[frontierIndex].push(existingShips[legacyIndex]);
+  });
+
+  // Remove leftover no-ID records that describe a ship already represented by
+  // Frontier. These are duplicates from older journal/import behavior. Attach
+  // any useful customization to one matching Frontier record before removal.
+  existingShips.forEach((existingShip, existingIndex) => {
+    if (claimedIndexes.has(existingIndex)) return;
+    if (normalizeOwnedShipId(existingShip.frontier_id)) return;
+
+    const frontierIndex = frontierShips.findIndex((frontierShip) =>
+      hasSameLegacyIdentity(existingShip, frontierShip)
+    );
+    if (frontierIndex < 0) return;
+
+    claimedIndexes.add(existingIndex);
+    customizationCandidates[frontierIndex].push(existingShip);
+  });
+
+  const mergedFrontierShips = frontierShips.map((frontierShip, frontierIndex) => {
+    const customization = pickCustomization(
+      frontierShip,
+      customizationCandidates[frontierIndex]
+    );
+    return {
+      ...frontierShip,
+      ...customization,
+    };
+  });
+
+  const localOnlyShips = existingShips.filter((ship, index) =>
+    !claimedIndexes.has(index) && ship.source !== 'frontier'
+  );
+  return [...mergedFrontierShips, ...localOnlyShips];
+};
+
+export const upsertJournalShip = (journalShip, existingShips = []) => {
+  const frontierId = normalizeOwnedShipId(journalShip?.frontier_id);
+  const incoming = {
+    ...journalShip,
+    ...(frontierId ? { frontier_id: frontierId } : {}),
+    kind_short: String(journalShip?.kind_short || '').trim().toLowerCase(),
+    name: String(journalShip?.name ?? '').trim(),
+    plate: String(journalShip?.plate ?? '').trim(),
+  };
+
+  let existingIndex = -1;
+  if (frontierId) {
+    existingIndex = existingShips.findIndex((ship) =>
+      normalizeOwnedShipId(ship.frontier_id) === frontierId
+    );
+  }
+
+  if (existingIndex < 0) {
+    existingIndex = existingShips.findIndex((ship) =>
+      // When the journal supplies a stable ID, only migrate an ID-less legacy
+      // record. Never collapse another owned ship that has a different ID.
+      (!frontierId || !normalizeOwnedShipId(ship.frontier_id)) &&
+      hasSameLegacyIdentity(ship, incoming)
+    );
+  }
+
+  if (existingIndex < 0) {
+    const addedShip = {
+      ...incoming,
+      ...(frontierId ? { record_id: `journal:${frontierId}` } : {}),
+      source: 'journal',
+    };
+    return {
+      ships: [...existingShips, addedShip],
+      ship: addedShip,
+      changed: true,
+      added: true,
+    };
+  }
+
+  const existing = existingShips[existingIndex];
+  const sameModel = hasSameModel(existing, incoming);
+  const { custom_name: _legacyName, ...existingWithoutLegacyName } = existing;
+  const updatedShip = sameModel
+    ? {
+        ...existingWithoutLegacyName,
+        ...incoming,
+        record_id: existing.record_id || (frontierId ? `journal:${frontierId}` : undefined),
+        frontier_id: frontierId || normalizeOwnedShipId(existing.frontier_id) || undefined,
+        source: existing.source || 'journal',
+        theme: existing.theme || incoming.theme,
+        image: existing.image || incoming.image,
+      }
+    : {
+        ...incoming,
+        ...(frontierId ? {
+          record_id: `journal:${frontierId}`,
+          frontier_id: frontierId,
+        } : {}),
+        source: 'journal',
+      };
+
+  const ships = [...existingShips];
+  ships[existingIndex] = updatedShip;
+  return {
+    ships,
+    ship: updatedShip,
+    changed: JSON.stringify(existing) !== JSON.stringify(updatedShip),
+    added: false,
+  };
+};

--- a/source_v3/src/Helpers/FrontierOAuth.mjs
+++ b/source_v3/src/Helpers/FrontierOAuth.mjs
@@ -1,0 +1,49 @@
+export const FRONTIER_AUTH_SCHEME = 'edhm';
+export const FRONTIER_AUTH_HOST = 'frontier-auth';
+export const FRONTIER_REDIRECT_URI = `${FRONTIER_AUTH_SCHEME}://${FRONTIER_AUTH_HOST}`;
+
+const normalizeProtocolArgument = (value) => {
+  const argument = String(value || '').trim();
+  if (argument.startsWith('"') && argument.endsWith('"')) return argument.slice(1, -1);
+  return argument;
+};
+
+export const parseFrontierAuthCallback = (value) => {
+  const argument = normalizeProtocolArgument(value);
+  if (!argument) return null;
+
+  try {
+    const callbackUrl = new URL(argument);
+    if (
+      callbackUrl.protocol !== `${FRONTIER_AUTH_SCHEME}:` ||
+      callbackUrl.hostname !== FRONTIER_AUTH_HOST ||
+      callbackUrl.port ||
+      callbackUrl.username ||
+      callbackUrl.password ||
+      callbackUrl.hash ||
+      (callbackUrl.pathname && callbackUrl.pathname !== '/')
+    ) {
+      return null;
+    }
+
+    return {
+      url: callbackUrl.toString(),
+      code: callbackUrl.searchParams.get('code') || '',
+      state: callbackUrl.searchParams.get('state') || '',
+      error: callbackUrl.searchParams.get('error') || '',
+      errorDescription: callbackUrl.searchParams.get('error_description') || '',
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const findFrontierAuthCallback = (args = []) => {
+  for (const argument of args) {
+    if (parseFrontierAuthCallback(argument)) return normalizeProtocolArgument(argument);
+  }
+  return null;
+};
+
+export const filterFrontierAuthArguments = (args = []) =>
+  args.filter((argument) => !parseFrontierAuthCallback(argument));

--- a/source_v3/src/Helpers/PlatformDefaults.mjs
+++ b/source_v3/src/Helpers/PlatformDefaults.mjs
@@ -1,0 +1,33 @@
+export const WINDOWS_PLAYER_JOURNAL_DEFAULT =
+  '%USERPROFILE%\\Saved Games\\Frontier Developments\\Elite Dangerous';
+
+export const LINUX_PLAYER_JOURNAL_DEFAULT =
+  '~/.local/share/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved Games/Frontier Developments/Elite Dangerous';
+
+const normalizeDefaultPath = (value) => String(value || '')
+  .trim()
+  .replace(/\\/g, '/')
+  .replace(/\/+$/g, '')
+  .toLowerCase();
+
+export const getDefaultPlayerJournal = (platform = process.platform) =>
+  platform === 'linux'
+    ? LINUX_PLAYER_JOURNAL_DEFAULT
+    : WINDOWS_PLAYER_JOURNAL_DEFAULT;
+
+export const applyPlatformSettingsDefaults = (settings, platform = process.platform) => {
+  if (!settings || typeof settings !== 'object') return false;
+
+  const configured = normalizeDefaultPath(settings.PlayerJournal);
+  const windowsDefault = normalizeDefaultPath(WINDOWS_PLAYER_JOURNAL_DEFAULT);
+  const linuxDefault = normalizeDefaultPath(LINUX_PLAYER_JOURNAL_DEFAULT);
+  const desiredDefault = getDefaultPlayerJournal(platform);
+
+  const shouldUsePlatformDefault = !configured ||
+    (platform === 'linux' && configured === windowsDefault) ||
+    (platform === 'win32' && configured === linuxDefault);
+
+  if (!shouldUsePlatformDefault || settings.PlayerJournal === desiredDefault) return false;
+  settings.PlayerJournal = desiredDefault;
+  return true;
+};

--- a/source_v3/src/Helpers/SettingsHelper.js
+++ b/source_v3/src/Helpers/SettingsHelper.js
@@ -10,6 +10,7 @@ import themeHelper from './ThemeHelper.js';
 import INIparser from './IniParser.js';
 import Log from './LoggingHelper.js';
 import Util from './Utils.js';
+import { applyPlatformSettingsDefaults } from './PlatformDefaults.mjs';
 
 /*----------------------------------------------------------------------------------------------------------------------------*/
 let programSettings = null; // Holds the Program Settings in memory
@@ -71,6 +72,7 @@ export const initializeSettings = async () => {
       // Load default settings from file
       const defaultSettings = fs.readFileSync(defaultSettingsPath, 'utf8');
       programSettings = JSON.parse(defaultSettings);
+      applyPlatformSettingsDefaults(programSettings);
 
       // Set the user data folder path in the settings
       programSettings.UserDataFolder = userSettingsDir;
@@ -89,6 +91,13 @@ export const initializeSettings = async () => {
 
       // Ensure the user data folder path is set
       programSettings.UserDataFolder = userSettingsDir;
+
+      // Migrate only untouched cross-platform defaults. Explicit custom
+      // journal locations are preserved.
+      if (applyPlatformSettingsDefaults(programSettings)) {
+        fs.writeFileSync(programSettingsPath, JSON.stringify(programSettings, null, 4));
+        console.log('Player Journal path updated for this platform.');
+      }
 
       console.log('Settings Loaded from Existing Instance.');
     }

--- a/source_v3/src/MainWindow/ShipyardNew.js
+++ b/source_v3/src/MainWindow/ShipyardNew.js
@@ -8,6 +8,13 @@ import EventBus from '../EventBus.js';
 import settingsHelper from '../Helpers/SettingsHelper.js';
 import fileHelper from '../Helpers/FileHelper.js';
 import KeySender from '../Helpers/KeySender.js';
+import FrontierApi from '../Helpers/FrontierApi.js';
+import {
+    mergeFrontierShips,
+    normalizeFrontierShips,
+    upsertJournalShip,
+} from '../Helpers/FrontierFleet.mjs';
+import { getDefaultPlayerJournal } from '../Helpers/PlatformDefaults.mjs';
 
 /*         
 * The Player Journal is a log file that contains information about the player's actions and events in the game.
@@ -31,6 +38,7 @@ class Shipyard extends EventEmitter {
         this.shipyardData = null;
         this.shipListData = null;
         this.PreviousShip = null;
+        this.frontierApi = new FrontierApi();
 
         this.linesProcessed = 0;
         this.currentlyMonitoredFile = null;
@@ -44,9 +52,7 @@ class Shipyard extends EventEmitter {
             this.LOG_DIRECTORY = fileHelper.resolveEnvVariables(
                 settingsHelper.readSetting(
                     'PlayerJournal',
-                    process.platform === 'win32'
-                        ? '%USERPROFILE%\\Saved Games\\Frontier Developments\\Elite Dangerous'
-                        : '~/.local/share/Steam/steamapps/compatdata/359320/pfx/drive_c/users/steamuser/Saved Games/Frontier Developments/Elite Dangerous'
+                    getDefaultPlayerJournal()
                 )
             ); console.log('Shipyard Journal Dir: ', this.LOG_DIRECTORY);
 
@@ -93,14 +99,71 @@ class Shipyard extends EventEmitter {
             return true;
         } catch (error) {
             console.error('Error saving ship data:', error);
-            this.shipyardData.ships.pop();
             return false;
         }
     }
 
+    getFrontierShips(profile) {
+        return normalizeFrontierShips(profile, this.shipListData);
+    }
+
+    async mergeFrontierFleet(profile, galaxy = 'live') {
+        if (!profile || typeof profile !== 'object') {
+            throw new Error('Frontier returned an invalid Commander profile.');
+        }
+
+        const existingShips = Array.isArray(this.shipyardData?.ships) ? this.shipyardData.ships : [];
+        // Frontier is authoritative for records imported by Frontier. The
+        // helper preserves themes/images and retains unmatched Journal/V2 data.
+        const frontierShips = this.getFrontierShips(profile);
+        if (frontierShips.length === 0) {
+            throw new Error(
+                'Frontier returned a Commander profile without any ships. Existing Shipyard data was left unchanged.'
+            );
+        }
+        const mergedShips = mergeFrontierShips(frontierShips, existingShips);
+        const commanderName = String(profile.commander?.name || this.shipyardData?.player_name || '').trim();
+        this.shipyardData = {
+            ...this.shipyardData,
+            player_name: commanderName,
+            ships: mergedShips,
+            frontier: {
+                last_sync_at: new Date().toISOString(),
+                ship_count: frontierShips.length,
+                galaxy,
+            },
+        };
+
+        if (!this.SaveShipyard()) {
+            throw new Error('The Frontier fleet was received but could not be saved to Shipyard_v3.json.');
+        }
+        await this.frontierApi.recordFleetSync(commanderName, frontierShips.length);
+
+        const payload = {
+            shipyard: this.shipyardData,
+            shipList: this.shipListData,
+            frontierStatus: await this.frontierApi.getStatus(),
+        };
+        this.mainWindow.webContents.send('shipyard:fleetUpdated', payload);
+        return payload;
+    }
+
+    async syncFrontierFleet(authorize = false) {
+        if (!this.shipListData || !this.shipyardData) await this.initialize();
+        if (authorize) await this.frontierApi.authorize();
+        const activeInstance = settingsHelper.getActiveInstance();
+        const galaxy = activeInstance?.key === 'ED_Horizons' ? 'legacy' : 'live';
+        const profile = await this.frontierApi.fetchProfile(galaxy);
+        return this.mergeFrontierFleet(profile, galaxy);
+    }
+
+    handleFrontierAuthCallback(callbackUrl) {
+        return this.frontierApi.handleAuthorizationCallback(callbackUrl);
+    }
+
     async startMonitoring() {
-        const DirExists = await fileHelper.checkFileExists(this.LOG_DIRECTORY);
-        if (!this.LOG_DIRECTORY && DirExists) {
+        const DirExists = this.LOG_DIRECTORY && fileHelper.checkFileExists(this.LOG_DIRECTORY);
+        if (!this.LOG_DIRECTORY || !DirExists) {
             const error = { type: 'monitoring', error: '404 - JOURNAL_DIRECTORY not found.' };
             console.error(error);
             this.emit('error', error);
@@ -263,6 +326,7 @@ class Shipyard extends EventEmitter {
                     _data = {
                         event: 'ShipLoadout',
                         data: this.GetShip({
+                            frontier_id: _json.ShipID,
                             kind_short: _json.Ship,
                             name: _json.ShipName?.trim(),
                             plate: _json.ShipIdent
@@ -359,6 +423,7 @@ class Shipyard extends EventEmitter {
 
     /** Get the ship data from the ShipList based on the given parameters. 
      * @param {*} shipData - Parameters containing ship information.
+     * @param {string|number} shipData.frontier_id - Stable owned-ship ID shared by the journal and CAPI.
      * @param {string} shipData.kind_short - [Required] The ship kind (e.g., "python", "cutter").
      * @param {string} shipData.name -  The ship name (e.g., "NORMANDY").
      * @param {string} shipData.plate - The ship plate (e.g., "SR-03"). */
@@ -369,6 +434,7 @@ class Shipyard extends EventEmitter {
                 const ship = this.shipListData.find(ship => ship.ed_short.toLowerCase() === sKindShort);
                 if (ship) {
                     return {
+                        frontier_id: shipData.frontier_id,
                         ship_id: ship.ship_id,
                         kind_short: ship.ed_short.toLowerCase(),
                         kind_full: ship.ship_full_name,
@@ -394,36 +460,23 @@ class Shipyard extends EventEmitter {
             return shipData;
         }
 
-        const kind_short = shipData.kind_short?.toLowerCase().trim() ?? '';
-        const name = shipData.name;
-        const plate = shipData.plate;
-        let exShip = null;
+        const result = upsertJournalShip(shipData, this.shipyardData.ships);
+        this.shipyardData.ships = result.ships;
 
-        const shipExists = this.shipyardData.ships.some(existingShip => {
-            const existingKindShort = existingShip.kind_short?.toLowerCase().trim() ?? '';
-            const existingName = existingShip.name;
-            const existingPlate = existingShip.plate;
-            exShip = existingShip;
-            return existingKindShort === kind_short && existingName === name && existingPlate === plate;
-        });
-
-        if (shipExists) {
-            //console.log(`Ship not added: A ship with kind_short '${kind_short}', name '${name}', and plate '${plate}' already exists.`);
-            return exShip;
-        } else {
-            const newShip = { ...shipData };
-            this.shipyardData.ships.push(newShip);
+        if (result.changed) {
             this.SaveShipyard();
 
-            // Emitir evento al Renderer
             this.mainWindow.webContents.send('shipyard-ShipAdded', {
                 shipyard: this.shipyardData,
                 shipList: this.shipListData,
             });
 
-            console.log(`New Ship added to Shipyard: ${newShip.kind_short}, file Saved.`);
-            return shipData;
+            console.log(
+                `${result.added ? 'New ship added' : 'Ship identity updated'}: ` +
+                `${result.ship.kind_short}, file saved.`
+            );
         }
+        return result.ship;
     }
 
     setupIPC() {
@@ -479,6 +532,16 @@ class Shipyard extends EventEmitter {
                 console.error('Error updating config:', err);
                 return { success: false, error: err.message };
             }
+        });
+
+        ipcMain.handle('shipyard:frontierStatus', () => this.frontierApi.getStatus());
+        ipcMain.handle('shipyard:frontierTokenPath', () => this.frontierApi.tokenFilePath);
+        ipcMain.handle('shipyard:frontierLogin', () => this.syncFrontierFleet(true));
+        ipcMain.handle('shipyard:frontierCancelLogin', () => this.frontierApi.cancelAuthorization());
+        ipcMain.handle('shipyard:frontierRefresh', () => this.syncFrontierFleet(false));
+        ipcMain.handle('shipyard:frontierLogout', async () => {
+            await this.frontierApi.clearTokens();
+            return this.frontierApi.getStatus();
         });
     }
 

--- a/source_v3/src/MainWindow/ShipyardUI.vue
+++ b/source_v3/src/MainWindow/ShipyardUI.vue
@@ -10,6 +10,41 @@
 
                     <!-- Main Content -->
                     <div class="container-fluid h-100">
+                        <div class="frontier-panel d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3 p-3">
+                            <div>
+                                <div class="fw-semibold">Frontier Fleet</div>
+                                <div class="small" :class="frontierStatus.authorized ? 'text-success' : 'text-warning'">
+                                    {{ frontierStatusText }}
+                                </div>
+                            </div>
+                            <div class="btn-group" role="group" aria-label="Frontier fleet controls">
+                                <button ref="frontierDataButton" type="button" class="btn btn-sm btn-outline-info"
+                                    @click="openFrontierDataInfo">
+                                    <i class="bi bi-shield-lock me-1" aria-hidden="true"></i>
+                                    About my data
+                                </button>
+                                <template v-if="!frontierStatus.authorized">
+                                    <button v-if="frontierBusy" type="button" class="btn btn-sm btn-outline-warning"
+                                        :disabled="frontierCancelRequested" @click="cancelFrontierConnection">
+                                        <span v-if="frontierCancelRequested" class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                        {{ frontierCancelRequested ? 'Cancelling...' : 'Cancel Connection' }}
+                                    </button>
+                                    <button v-else type="button" class="btn btn-sm btn-primary" @click="connectFrontier">
+                                        Connect Frontier
+                                    </button>
+                                </template>
+                                <template v-else>
+                                    <button type="button" class="btn btn-sm btn-success" :disabled="frontierBusy"
+                                        @click="refreshFrontierFleet">
+                                        <span v-if="frontierBusy" class="spinner-border spinner-border-sm me-1" aria-hidden="true"></span>
+                                        Refresh Fleet
+                                    </button>
+                                    <button type="button" class="btn btn-sm btn-outline-danger" :disabled="frontierBusy"
+                                        @click="disconnectFrontier">Disconnect</button>
+                                </template>
+                            </div>
+                        </div>
+
                         <!-- Alert to show the 'Read Me' information of the selected mod -->
                         <div v-show="showInfo" class="alert alert-warning alert-dismissible" role="alert">
                             <button type="button" class="btn-close" aria-label="Close" @click="closeInfo"></button>
@@ -17,7 +52,7 @@
                         </div>
 
                         <div class="row row-cols-1 row-cols-md-3 g-4">
-                            <div v-for="ship in filteredShips" :key="ship.ship_id" class="col"
+                            <div v-for="ship in filteredShips" :key="ship.record_id || ship.frontier_id || `${ship.kind_short}:${ship.name}:${ship.plate}`" class="col"
                                 :class="{ 'selected-card': selectedShip === ship }" @click="selectCard(ship)">
 
                                 <div class="card bg-secondary text-light">
@@ -58,14 +93,14 @@
                             <input class="form-check-input" type="checkbox" value="" id="checkNativeSwitch" checked
                                 v-model="shipData.enabled" switch>
                             <label class="form-check-label" for="checkNativeSwitch">
-                                Shipyard {{ shipData.enabled ? 'Enabled' : 'Disabled' }}
+                                Journal Monitor {{ shipData.enabled ? 'Enabled' : 'Disabled' }}
                             </label>&nbsp;&nbsp;
                         </div>
                         <div class="btn-toolbar" role="toolbar" aria-label="Toolbar with button groups">
 
                             <div class="btn-group me-3" role="group" aria-label="First group">
                                 <button id="cmdReloadShips" class="btn btn-outline-secondary" type="button"
-                                    @mousedown="cmdReloadShips_Click" @mouseover="updateStatus('Reload Ships')"
+                                    @mousedown="cmdReloadShips_Click" @mouseover="updateStatus('Reload Journal Ships')"
                                     @mouseleave="clearStatus">
                                     <i class="bi bi-arrow-clockwise"></i>
                                 </button>
@@ -97,6 +132,71 @@
 
                 </div>
             </div>
+        </div>
+
+        <div v-if="showFrontierDataInfo" class="frontier-data-overlay" role="presentation"
+            @click.self="closeFrontierDataInfo">
+            <section ref="frontierDataDialog" class="frontier-data-dialog bg-dark text-light" role="dialog"
+                aria-modal="true" aria-labelledby="frontierDataTitle" tabindex="-1"
+                @keydown.esc="closeFrontierDataInfo">
+                <div class="frontier-data-header">
+                    <h5 id="frontierDataTitle" class="mb-0">About your Frontier data</h5>
+                    <button type="button" class="btn-close btn-close-white" aria-label="Close"
+                        @click="closeFrontierDataInfo"></button>
+                </div>
+
+                <div class="frontier-data-body">
+                    <div class="frontier-local-notice mb-3">
+                        <strong>Your Frontier fleet data stays on your computer.</strong>
+                        EDHM-UI does not upload your Commander or fleet information to an EDHM-UI server or collect it
+                        anywhere else. Your profile is requested directly from Frontier's Companion API and processed
+                        locally only to populate the Shipyard and keep your owned ships matched with their theme and
+                        image settings.
+                    </div>
+
+                    <h6>What EDHM-UI keeps</h6>
+                    <ul>
+                        <li>Your Commander name.</li>
+                        <li>Each owned ship's Frontier ID, model, custom name, and ship identifier.</li>
+                        <li>The time, ship count, and active galaxy from the latest fleet refresh.</li>
+                        <li>Your local per-ship theme and image choices.</li>
+                    </ul>
+
+                    <h6>What EDHM-UI does not keep</h6>
+                    <p>
+                        Frontier returns a broader Commander profile, but EDHM-UI does not save the raw response or
+                        retain credits, ranks, location, cargo, modules, loadouts, or market data. The saved fleet data
+                        remains in your local EDHM-UI user-data folder and is not sent to an EDHM-UI server.
+                    </p>
+
+                    <h6>Authorization and privacy</h6>
+                    <p>
+                        Frontier provides the <strong>auth</strong> and <strong>capi</strong> permissions used here.
+                        Frontier does not provide a fleet-only permission, so EDHM-UI limits its own use of the returned
+                        profile to the Shipyard information listed above. Access and refresh tokens are encrypted using
+                        your operating system's secure storage and are never written into the Shipyard data file.
+                        Disconnecting removes the locally stored Frontier authorization tokens but keeps your Shipyard
+                        records and customizations.
+                    </p>
+
+                    <h6>Where authorization is stored</h6>
+                    <p class="mb-2">Encrypted Frontier access and refresh tokens:</p>
+                    <div class="frontier-storage-path mb-2"><code>{{ frontierTokenFilePath }}</code></div>
+                    <button type="button" class="btn btn-sm btn-outline-light"
+                        @click="openFrontierStorageFolder(frontierTokenFilePath)">
+                        <i class="bi bi-folder2-open me-1" aria-hidden="true"></i>
+                        Open authorization data folder
+                    </button>
+                </div>
+
+                <div class="frontier-data-footer">
+                    <button type="button" class="btn btn-outline-info" @click="openFrontierDeveloperDocs">
+                        Frontier API authentication documentation
+                        <i class="bi bi-box-arrow-up-right ms-1" aria-hidden="true"></i>
+                    </button>
+                    <button type="button" class="btn btn-secondary" @click="closeFrontierDataInfo">Close</button>
+                </div>
+            </section>
         </div>
     </div>
 </template>
@@ -136,7 +236,19 @@ export default {
         return {
             visible: false,
             showSpinner: false,        //<- Flag to Show/hide the Loading Spinner            
-            statusText: 'Ready.',
+            shipyardMessage: '',
+            frontierBusy: false,
+            frontierCancelRequested: false,
+            showFrontierDataInfo: false,
+            frontierTokenFilePath: '',
+            frontierStatus: {
+                authorized: false,
+                commanderName: '',
+                expiresAt: null,
+                lastSyncAt: null,
+                shipCount: 0,
+            },
+            removeFleetUpdatedListener: null,
 
             ActiveInstance: null,
             showAlert: false,       //<- Flag to Show/hide the Install/Update Alert
@@ -172,7 +284,17 @@ export default {
             );
         },
         statusText() {
+            if (this.shipyardMessage) return this.shipyardMessage;
             return `${this.filteredShips.length} of ${this.ships.length} ships`;
+        },
+        frontierStatusText() {
+            if (this.frontierBusy) return 'Waiting for Frontier...';
+            if (!this.frontierStatus.authorized) return 'Not connected';
+            const commander = this.frontierStatus.commanderName
+                ? `Connected as CMDR ${this.frontierStatus.commanderName}`
+                : 'Connected';
+            if (!this.frontierStatus.lastSyncAt) return commander;
+            return `${commander} · ${this.frontierStatus.shipCount} ships · Last refreshed ${new Date(this.frontierStatus.lastSyncAt).toLocaleString()}`;
         }
     },
     methods: {
@@ -184,8 +306,10 @@ export default {
                 this.showAlert = false;
 
                 this.DATA_DIRECTORY = await window.api.GetProgramDataDirectory();
-
-                
+                await Promise.all([
+                    this.loadFrontierStatus(),
+                    this.loadFrontierTokenPath(),
+                ]);
 
             } catch (error) {
                 this.showSpinner = false;
@@ -197,7 +321,7 @@ export default {
                 }, 1000);
             }
         },
-        async loadShipData(themes) {
+        async loadShipData(themes = this.themes) {
             this.showSpinner = true;
             //const ShipyardFilePath = await window.api.joinPath(this.DATA_DIRECTORY, 'Shipyard_v3.json');
             const ShyardData = await window.shipyardAPI.getConfig(); //console.log('shipData', this.shipData);
@@ -207,8 +331,8 @@ export default {
                     ...ship,
                     imageUrl: await this.getShipImage(ship.image) // Resolve the promise here
                 })));
-                this.themes = themes;
-                this.statusText = `${this.ships.length} Ships Loaded.`;
+                this.themes = themes || this.themes;
+                this.shipyardMessage = `${this.ships.length} Ships Loaded.`;
             }
             this.showSpinner = false;
         },
@@ -243,21 +367,48 @@ export default {
         async open(data) {
             this.visible = true;
             this.ActiveInstance = data;
-            this.Initialize();
+            await this.Initialize();
+            await this.loadShipData(this.themesData || this.themes);
             console.log('Poping Shipyard UI..');
         },
         close() {
+            this.showFrontierDataInfo = false;
             this.visible = false;
+        },
+        openFrontierDataInfo() {
+            this.showFrontierDataInfo = true;
+            this.$nextTick(() => this.$refs.frontierDataDialog?.focus());
+        },
+        closeFrontierDataInfo() {
+            this.showFrontierDataInfo = false;
+            this.$nextTick(() => this.$refs.frontierDataButton?.focus());
+        },
+        openFrontierDeveloperDocs() {
+            window.api.openUrlInBrowser('https://user.frontierstore.net/developer/docs');
+        },
+        async loadFrontierTokenPath() {
+            this.frontierTokenFilePath = await window.shipyardAPI.frontierTokenPath();
+        },
+        async openFrontierStorageFolder(filePath) {
+            if (!filePath) {
+                EventBus.emit('ShowError', new Error('The local Frontier storage path is not available.'));
+                return;
+            }
+            try {
+                await window.api.openPathInExplorer(window.api.getParentFolder(filePath));
+            } catch (error) {
+                EventBus.emit('ShowError', error);
+            }
         },
         sanitizeId(id) {
             /* Cleans html tags */
             return id.replace(/\s/g, '');
         },
         updateStatus(message) {
-            this.statusText = message;
+            this.shipyardMessage = message;
         },
         clearStatus() {
-            this.statusText = '';
+            this.shipyardMessage = '';
         },
         closeInfo() {
             this.showInfo = false;
@@ -289,7 +440,7 @@ export default {
 
                 try {
                     await window.api.copyFile(selectedImagePath, destinationPath);
-                    const index = this.ships.findIndex(s => s.ship_id === ship.ship_id);
+                    const index = this.ships.findIndex(s => this.isSameShip(s, ship));
                     if (index !== -1) {
                         // Update the ship object
                         this.ships[index] = {
@@ -310,11 +461,11 @@ export default {
             console.log(`Theme changed for ${ship.name} to: ${ship.theme}`);
             try {
                 await this.saveShipData();
-                this.statusText = `Theme for ${ship.name} updated and saved.`;
+                this.shipyardMessage = `Theme for ${ship.name} updated and saved.`;
                 // Optionally, you can emit an event or show a notification to the user
             } catch (error) {
                 console.error('Error saving ship data:', error);
-                this.statusText = 'Error saving ship data.';
+                this.shipyardMessage = 'Error saving ship data.';
                 EventBus.emit('ShowError', 'Failed to save ship data.');
             }
         },
@@ -323,6 +474,107 @@ export default {
             this.selectedShip = ship;
             console.log('Selected ship:', ship);
             this.$emit('shipSelected', ship); // Emitimos el evento usando this.$emit
+        },
+
+        isSameShip(left, right) {
+            if (left.record_id && right.record_id) return left.record_id === right.record_id;
+            if (left.frontier_id != null && right.frontier_id != null) {
+                return String(left.frontier_id) === String(right.frontier_id);
+            }
+            return left.kind_short === right.kind_short && left.name === right.name && left.plate === right.plate;
+        },
+
+        async loadFrontierStatus() {
+            this.frontierStatus = await window.shipyardAPI.frontierStatus();
+        },
+
+        async connectFrontier() {
+            this.frontierBusy = true;
+            this.frontierCancelRequested = false;
+            this.shipyardMessage = 'Waiting for Frontier authorization...';
+            EventBus.emit('RoastMe', {
+                type: 'Info',
+                title: 'Connect Frontier',
+                message: 'Your browser will open Frontier authorization.<br>' +
+                    'After approval, allow the browser to open EDHM-UI to complete the connection. ' +
+                    'No localhost certificate exception is required.',
+                autoHide: false,
+                width: '520px',
+            });
+            try {
+                const result = await window.shipyardAPI.frontierLogin();
+                this.frontierStatus = result.frontierStatus;
+                await this.loadShipData(this.themes);
+                this.shipyardMessage = `${result.frontierStatus.shipCount} Frontier ships refreshed.`;
+                EventBus.emit('RoastMe', {
+                    type: 'Success',
+                    message: `Frontier connected. ${result.frontierStatus.shipCount} ships loaded into the Shipyard.`,
+                });
+            } catch (error) {
+                if (this.frontierCancelRequested) {
+                    this.shipyardMessage = 'Frontier connection cancelled.';
+                } else {
+                    EventBus.emit('ShowError', error);
+                }
+            } finally {
+                EventBus.emit('closeToast', 'Info');
+                this.frontierBusy = false;
+                this.frontierCancelRequested = false;
+                await this.loadFrontierStatus().catch(() => {});
+            }
+        },
+
+        async cancelFrontierConnection() {
+            if (!this.frontierBusy || this.frontierCancelRequested) return;
+
+            this.frontierCancelRequested = true;
+            this.shipyardMessage = 'Cancelling Frontier connection...';
+            try {
+                const cancelled = await window.shipyardAPI.frontierCancelLogin();
+                if (!cancelled) {
+                    this.frontierCancelRequested = false;
+                    this.shipyardMessage = 'Completing Frontier connection...';
+                }
+            } catch (error) {
+                this.frontierCancelRequested = false;
+                EventBus.emit('ShowError', error);
+            }
+        },
+
+        async refreshFrontierFleet() {
+            this.frontierBusy = true;
+            this.shipyardMessage = 'Refreshing fleet from Frontier...';
+            try {
+                const result = await window.shipyardAPI.frontierRefresh();
+                this.frontierStatus = result.frontierStatus;
+                await this.loadShipData(this.themes);
+                this.shipyardMessage = `${result.frontierStatus.shipCount} Frontier ships refreshed.`;
+                EventBus.emit('RoastMe', {
+                    type: 'Success',
+                    message: `${result.frontierStatus.shipCount} ships refreshed from Frontier.`,
+                });
+            } catch (error) {
+                EventBus.emit('ShowError', error);
+            } finally {
+                this.frontierBusy = false;
+                await this.loadFrontierStatus().catch(() => {});
+            }
+        },
+
+        async disconnectFrontier() {
+            this.frontierBusy = true;
+            try {
+                this.frontierStatus = await window.shipyardAPI.frontierLogout();
+                this.shipyardMessage = 'Frontier account disconnected. Stored ships were retained.';
+                EventBus.emit('RoastMe', {
+                    type: 'Success',
+                    message: 'Frontier authorization removed. Existing Shipyard data was retained.',
+                });
+            } catch (error) {
+                EventBus.emit('ShowError', error);
+            } finally {
+                this.frontierBusy = false;
+            }
         },
 
         async cmdReloadShips_Click(e) {
@@ -337,7 +589,7 @@ export default {
          cmdImportFromV2_Click(e) {
             this.ImportShipyardV2(); // Call the method to import ships from V2
             this.loadShipData(this.themes);
-            this.statusText = 'Ships imported from V2.';
+            this.shipyardMessage = 'Ships imported from V2.';
         },
         async cmdDeleteShip_Click(e) {
             if (this.selectedShip) {
@@ -353,11 +605,11 @@ export default {
                 };
                 const result = await window.api.ShowMessageBox(options);
                 if (result && result.response === 1) {
-                    const index = this.ships.findIndex(s => s.ship_id === this.selectedShip.ship_id);
+                    const index = this.ships.findIndex(s => this.isSameShip(s, this.selectedShip));
                     if (index !== -1) {
                         this.ships.splice(index, 1); // Remove the ship from the array
                         this.selectedShip = null; // Clear the selected ship
-                        this.statusText = 'Ship deleted.';
+                        this.shipyardMessage = 'Ship deleted.';
                         this.saveShipData(); // Save changes to the file
                     }
                 }
@@ -368,7 +620,9 @@ export default {
         cmdShowSomeInfo_Click(e) {
             this.showInfo = !this.showInfo;
             if (this.showInfo) {
-                this.infoMessage = 'The <b>Shipyard</b> is a feature that allows you to set a theme to each of your ships.<br>When you Embark your ship, the app will detect the change and automatically apply the selected theme.'; // Replace with actual info
+                this.infoMessage = 'The <b>Shipyard</b> allows you to set a theme for each ship.<br>' +
+                    'Connect Frontier to import your complete owned fleet without reading the Player Journal.<br>' +
+                    'The optional Journal Monitor detects when you embark a ship and automatically applies its assigned theme.';
             } else {
                 this.infoMessage = '';
             }
@@ -437,6 +691,11 @@ export default {
             console.log('@shipyard-ShipAdded', data);
             this.shipData = data.shipyard; 
             this.loadShipData(this.themes);
+        },
+
+        async OnFleetUpdated(data) {
+            this.frontierStatus = data.frontierStatus || this.frontierStatus;
+            await this.loadShipData(this.themes);
         }
 
 
@@ -446,12 +705,14 @@ export default {
         EventBus.on('open-ShipyardUI', this.open);
         EventBus.on('ShipyardUI-Initialize', this.Initialize);
         window.shipyardAPI.onShipAdded(this.OnShipAdded);
+        this.removeFleetUpdatedListener = window.shipyardAPI.onFleetUpdated(this.OnFleetUpdated);
     },
     beforeUnmount() {
         // Clean up the event listener:
         EventBus.off('open-ShipyardUI', this.open);
         EventBus.off('ShipyardUI-Initialize', this.Initialize);
         window.shipyardAPI?.onShipAdded(() => {});
+        this.removeFleetUpdatedListener?.();
     }
 };
 </script>
@@ -473,5 +734,86 @@ export default {
     /* Puedes personalizar el estilo de resaltado */
     box-shadow: 0 0 10px orange(0, 0, 255, 0.5);
     /* Ejemplo de sombra */
+}
+
+.frontier-panel {
+    background: #252a30;
+    border: 1px solid #495057;
+    border-radius: 0.375rem;
+}
+
+.frontier-data-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1080;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    background: rgba(0, 0, 0, 0.72);
+}
+
+.frontier-data-dialog {
+    display: flex;
+    flex-direction: column;
+    width: min(700px, 100%);
+    max-height: calc(100vh - 2rem);
+    border: 1px solid #495057;
+    border-radius: 0.5rem;
+    box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.55);
+}
+
+.frontier-data-header,
+.frontier-data-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem 1.25rem;
+}
+
+.frontier-data-header {
+    border-bottom: 1px solid #495057;
+}
+
+.frontier-data-body {
+    overflow-y: auto;
+    padding: 1rem 1.25rem;
+}
+
+.frontier-data-body h6 {
+    color: #6edff6;
+}
+
+.frontier-local-notice {
+    padding: 0.9rem 1rem;
+    color: #d9f7ff;
+    background: rgba(13, 202, 240, 0.12);
+    border: 1px solid rgba(110, 223, 246, 0.55);
+    border-left-width: 4px;
+    border-radius: 0.375rem;
+}
+
+.frontier-storage-path {
+    overflow-wrap: anywhere;
+    padding: 0.55rem 0.7rem;
+    background: #191c1f;
+    border: 1px solid #495057;
+    border-radius: 0.375rem;
+}
+
+.frontier-storage-path code {
+    color: #9eeaf9;
+}
+
+.frontier-data-footer {
+    flex-wrap: wrap;
+    border-top: 1px solid #495057;
+}
+
+@media (max-width: 575.98px) {
+    .frontier-data-footer > .btn {
+        width: 100%;
+    }
 }
 </style>

--- a/source_v3/src/main.js
+++ b/source_v3/src/main.js
@@ -1,10 +1,46 @@
 import { app, Menu, BrowserWindow, globalShortcut, ipcMain, shell, Tray, screen  } from 'electron';
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import started from 'electron-squirrel-startup';
 import fileHelper from './Helpers/FileHelper.js';
 import themeHelper from './Helpers/ThemeHelper.js';
 import settingsHelper from './Helpers/SettingsHelper.js';
 import Shipyard from './MainWindow/ShipyardNew.js';
+import {
+  filterFrontierAuthArguments,
+  findFrontierAuthCallback,
+  FRONTIER_AUTH_SCHEME,
+} from './Helpers/FrontierOAuth.mjs';
+
+const APP_DISPLAY_NAME = 'EDHM-UI-V3';
+
+function registerWindowsProtocolDisplayName() {
+  if (process.platform !== 'win32') return;
+
+  const classesRoot = 'HKCU\\Software\\Classes';
+  const registryWrites = [
+    ['add', `${classesRoot}\\${FRONTIER_AUTH_SCHEME}`, '/ve', '/t', 'REG_SZ', '/d', APP_DISPLAY_NAME, '/f'],
+  ];
+
+  if (!process.defaultApp) {
+    registryWrites.push([
+      'add',
+      `${classesRoot}\\Applications\\${path.basename(process.execPath)}`,
+      '/v', 'FriendlyAppName',
+      '/t', 'REG_SZ',
+      '/d', APP_DISPLAY_NAME,
+      '/f',
+    ]);
+  }
+
+  try {
+    for (const args of registryWrites) {
+      execFileSync('reg.exe', args, { stdio: 'ignore', windowsHide: true });
+    }
+  } catch (error) {
+    console.warn(`EDHM-UI could not register its Windows protocol display name: ${error.message}`);
+  }
+}
 
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
@@ -19,6 +55,47 @@ let StartMinimizedToTray = false;
 let shipyard;
 let CustomIcon;
 let programSettings;
+const pendingFrontierAuthCallbacks = [];
+
+function registerFrontierAuthProtocol() {
+  try {
+    const registered = process.defaultApp && process.argv[1]
+      ? app.setAsDefaultProtocolClient(
+        FRONTIER_AUTH_SCHEME,
+        process.execPath,
+        [path.resolve(process.argv[1])]
+      )
+      : app.setAsDefaultProtocolClient(FRONTIER_AUTH_SCHEME);
+
+    if (!registered) {
+      console.error('EDHM-UI could not register the edhm:// protocol handler.');
+    } else {
+      registerWindowsProtocolDisplayName();
+    }
+  } catch (error) {
+    console.error('Unable to register the edhm:// protocol handler:', error);
+  }
+}
+
+function dispatchFrontierAuthCallback(callbackUrl) {
+  if (!callbackUrl) return false;
+  if (!shipyard) {
+    pendingFrontierAuthCallbacks.push(callbackUrl);
+    return true;
+  }
+  return shipyard.handleFrontierAuthCallback(callbackUrl);
+}
+
+function dispatchFrontierAuthArguments(args) {
+  return dispatchFrontierAuthCallback(findFrontierAuthCallback(args));
+}
+
+function flushFrontierAuthCallbacks() {
+  if (!shipyard) return;
+  for (const callbackUrl of pendingFrontierAuthCallbacks.splice(0)) {
+    shipyard.handleFrontierAuthCallback(callbackUrl);
+  }
+}
 
 
 //- Check for Single Instance:
@@ -27,6 +104,7 @@ if (!gotTheLock) {
   app.quit(); // Si otra instancia ya está corriendo, cerramos esta.
 } else {
   app.on('second-instance', (event, commandLine, workingDirectory) => {
+    dispatchFrontierAuthArguments(commandLine);
     if (mainWindow) {
       if (mainWindow.isMinimized()) {
         mainWindow.restore(); // Restaura si estaba minimizada.
@@ -34,6 +112,10 @@ if (!gotTheLock) {
       mainWindow.show();  // Muestra la ventana si estaba oculta.
       mainWindow.focus(); // Asegura que la ventana tenga el foco.
     }
+  });
+  app.on('open-url', (event, url) => {
+    event.preventDefault();
+    dispatchFrontierAuthCallback(url);
   });
   Start();
 }
@@ -98,6 +180,8 @@ async function Start() {
     // initialization and is ready to create browser windows.
     // Some APIs can only be used after this event occurs.
     app.whenReady().then(async () => {
+      registerFrontierAuthProtocol();
+
       // Ajustar el Escalado de imagen a la pantalla:
       const { size, scaleFactor: systemScale } = screen.getPrimaryDisplay();
       let userScale = settingsHelper.readSetting('UiScaleFactor', 0); // 0 = automático
@@ -134,11 +218,14 @@ async function Start() {
 
       // Handle command-line arguments
       const args = process.argv.slice(2);
-      if (args.length > 0) {
-        console.log('Command-line arguments:', args);
+      const frontierAuthCallback = findFrontierAuthCallback(args);
+      const appArgs = filterFrontierAuthArguments(args);
+      dispatchFrontierAuthCallback(frontierAuthCallback);
+      if (appArgs.length > 0) {
+        console.log('Command-line arguments:', appArgs);
 
         // Handle your arguments here
-        if (args.includes('--hide')) {
+        if (appArgs.includes('--hide')) {
           console.log('Program started with --hide argument.');
           // Hide the main window immediately
           mainWindow.hide();
@@ -150,7 +237,7 @@ async function Start() {
       const { scaleFactor } = screen.getPrimaryDisplay();      
       // Send arguments to the renderer process: App.vue
       mainWindow.webContents.on('did-finish-load', () => {
-        mainWindow.webContents.send('app-args', args);
+        mainWindow.webContents.send('app-args', appArgs);
         mainWindow.webContents.send('font-size-setting', FontSize);
         mainWindow.webContents.setZoomFactor(finalScale);
       });
@@ -229,6 +316,7 @@ const createWindow = () => {
   console.log('StartMinimizedToTray:', StartMinimizedToTray);
 
   shipyard = new Shipyard(mainWindow);
+  flushFrontierAuthCallbacks();
 
 
   // Register the shortcut to open DevTools

--- a/source_v3/src/preload.js
+++ b/source_v3/src/preload.js
@@ -220,10 +220,21 @@ contextBridge.exposeInMainWorld('shipyardAPI', {
   reloadConfig: () => ipcRenderer.invoke('shipyard:reloadConfig'), 
   getConfig: () => ipcRenderer.invoke('shipyard:getConfig'),
   updateConfig: (newConfig) => ipcRenderer.invoke('shipyard:updateConfig', newConfig),
+  frontierStatus: () => ipcRenderer.invoke('shipyard:frontierStatus'),
+  frontierTokenPath: () => ipcRenderer.invoke('shipyard:frontierTokenPath'),
+  frontierLogin: () => ipcRenderer.invoke('shipyard:frontierLogin'),
+  frontierCancelLogin: () => ipcRenderer.invoke('shipyard:frontierCancelLogin'),
+  frontierRefresh: () => ipcRenderer.invoke('shipyard:frontierRefresh'),
+  frontierLogout: () => ipcRenderer.invoke('shipyard:frontierLogout'),
 
   // Eventos
   onLogEntry: (callback) => ipcRenderer.on('shipyard:logEntry', (e, data) => callback(data)),
   onShipAdded: (callback) => ipcRenderer.on('shipyard-ShipAdded', (e, data) => callback(data)),
+  onFleetUpdated: (callback) => {
+    const listener = (e, data) => callback(data);
+    ipcRenderer.on('shipyard:fleetUpdated', listener);
+    return () => ipcRenderer.removeListener('shipyard:fleetUpdated', listener);
+  },
   
   onInvalidLine: (callback) => ipcRenderer.on('shipyard:invalidLine', (e, line) => callback(line)),
   onLogFileChanged: (callback) => ipcRenderer.on('shipyard:logFileChanged', (e, file) => callback(file)),

--- a/source_v3/test/frontier-fleet.test.mjs
+++ b/source_v3/test/frontier-fleet.test.mjs
@@ -1,0 +1,238 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  mergeFrontierShips,
+  normalizeFrontierShips,
+  normalizeShipSymbol,
+  upsertJournalShip,
+} from '../src/Helpers/FrontierFleet.mjs';
+
+const shipList = [
+  { ship_id: 9, ed_short: 'cobramkiii', ship_full_name: 'Cobra Mk 3' },
+  { ship_id: 35, ed_short: 'python', ship_full_name: 'Python' },
+];
+
+test('normalizes Frontier symbols and ID-keyed fleet responses', () => {
+  assert.equal(normalizeShipSymbol('$ShipName_CobraMkIII_Name;'), 'cobramkiii');
+  const ships = normalizeFrontierShips({
+    commander: { currentShipId: 42 },
+    ships: {
+      42: { id: 42, name: 'CobraMkIII', shipName: 'Raven', shipID: 'RVN-01' },
+      77: { id: 77, name: 'Python', shipName: 'Hauler', shipID: 'PY-77' },
+    },
+    ship: { id: 42, name: 'CobraMkIII', shipName: 'Raven', shipID: 'RVN-01' },
+  }, shipList);
+
+  assert.equal(ships.length, 2, 'current ship is not duplicated');
+  assert.deepEqual(ships[0], {
+    record_id: 'frontier:42',
+    frontier_id: '42',
+    ship_id: 9,
+    kind_short: 'cobramkiii',
+    kind_full: 'Cobra Mk 3',
+    name: 'Raven',
+    plate: 'RVN-01',
+    theme: 'Current Settings',
+    image: 'cobramkiii.jpg',
+    source: 'frontier',
+  });
+});
+
+test('supports array fleets and unknown ship models', () => {
+  const ships = normalizeFrontierShips({
+    ships: [{ id: 101, name: 'FutureShip', shipName: 'Prototype', shipID: 'NEW-01' }],
+  }, shipList);
+
+  assert.equal(ships[0].frontier_id, '101');
+  assert.equal(ships[0].kind_full, 'FutureShip');
+  assert.equal(ships[0].image, '@default.jpg');
+});
+
+test('preserves an intentionally blank custom ship name', () => {
+  const ships = normalizeFrontierShips({
+    ships: [{ id: 42, name: 'CobraMkIII', shipName: '', shipID: 'RVN-01' }],
+  }, shipList);
+
+  assert.equal(ships[0].name, '');
+  assert.equal(ships[0].kind_full, 'Cobra Mk 3');
+});
+
+test('fleet refresh preserves customizations and local-only records', () => {
+  const frontierShips = normalizeFrontierShips({
+    ships: [{ id: 42, name: 'CobraMkIII', shipName: 'Raven', shipID: 'RVN-01' }],
+  }, shipList);
+  const existingShips = [
+    {
+      frontier_id: '42', source: 'frontier', kind_short: 'cobramkiii', name: 'Raven', plate: 'RVN-01',
+      theme: 'Blue Theme', image: 'custom-raven.jpg',
+    },
+    {
+      frontier_id: '88', source: 'frontier', kind_short: 'python', name: 'Sold Ship', plate: 'OLD-88',
+      theme: 'Current Settings', image: 'python.jpg',
+    },
+    {
+      record_id: 'journal:srv', source: 'journal', kind_short: 'testbuggy', name: 'Scarab', plate: 'SRV_1',
+      theme: 'SRV Theme', image: 'testbuggy.jpg',
+    },
+  ];
+
+  const merged = mergeFrontierShips(frontierShips, existingShips);
+  assert.equal(merged.length, 2, 'sold Frontier records are removed while local records remain');
+  assert.equal(merged[0].theme, 'Blue Theme');
+  assert.equal(merged[0].image, 'custom-raven.jpg');
+  assert.equal(merged[1].record_id, 'journal:srv');
+});
+
+test('migrates legacy custom_name records without creating Frontier duplicates', () => {
+  const frontierShips = normalizeFrontierShips({
+    ships: [{ id: 23, name: 'Cutter', shipName: '', shipID: 'FE-17C' }],
+  }, [
+    ...shipList,
+    { ship_id: 23, ed_short: 'cutter', ship_full_name: 'Imperial Cutter' },
+  ]);
+  const existingShips = [{
+    ship_id: 23,
+    kind_short: 'cutter',
+    kind_full: 'Imperial Cutter',
+    custom_name: ' ',
+    plate: 'fe-17c ',
+    theme: 'Legacy Orange',
+    image: 'custom-cutter.jpg',
+  }];
+
+  const merged = mergeFrontierShips(frontierShips, existingShips);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].frontier_id, '23');
+  assert.equal(merged[0].name, '');
+  assert.equal(merged[0].theme, 'Legacy Orange');
+  assert.equal(merged[0].image, 'custom-cutter.jpg');
+  assert.equal('custom_name' in merged[0], false);
+});
+
+test('keeps same-model ships separate by Frontier ID even with identical names and plates', () => {
+  const frontierShips = normalizeFrontierShips({
+    ships: [
+      { id: 42, name: 'CobraMkIII', shipName: 'Raven', shipID: 'RVN-01' },
+      { id: 43, name: 'CobraMkIII', shipName: 'Raven', shipID: 'RVN-01' },
+    ],
+  }, shipList);
+  const existingShips = [
+    { frontier_id: '42', source: 'frontier', kind_short: 'cobramkiii', name: 'Raven', plate: 'RVN-01', theme: 'Blue' },
+    { frontier_id: '43', source: 'frontier', kind_short: 'cobramkiii', name: 'Raven', plate: 'RVN-01', theme: 'Green' },
+  ];
+
+  const merged = mergeFrontierShips(frontierShips, existingShips);
+  assert.equal(merged.length, 2);
+  assert.deepEqual(merged.map((ship) => [ship.frontier_id, ship.theme]), [
+    ['42', 'Blue'],
+    ['43', 'Green'],
+  ]);
+});
+
+test('removes an existing legacy duplicate while preserving its assigned theme', () => {
+  const frontierShips = normalizeFrontierShips({
+    ships: [{ id: 42, name: 'CobraMkIII', shipName: 'Raven', shipID: 'RVN-01' }],
+  }, shipList);
+  const existingShips = [
+    {
+      frontier_id: '42', source: 'frontier', kind_short: 'cobramkiii',
+      name: 'Raven', plate: 'RVN-01', theme: 'Current Settings', image: 'cobramkiii.jpg',
+    },
+    {
+      kind_short: 'CobraMkIII', custom_name: ' raven ', plate: 'rvn-01',
+      theme: 'Legacy Blue', image: 'custom-raven.jpg',
+    },
+  ];
+
+  const merged = mergeFrontierShips(frontierShips, existingShips);
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].frontier_id, '42');
+  assert.equal(merged[0].theme, 'Legacy Blue');
+  assert.equal(merged[0].image, 'custom-raven.jpg');
+});
+
+test('journal rename matches by stable ID and preserves the assigned theme', () => {
+  const existingShips = [{
+    record_id: 'frontier:42',
+    frontier_id: '42',
+    source: 'frontier',
+    kind_short: 'cobramkiii',
+    kind_full: 'Cobra Mk 3',
+    name: 'Old Name',
+    plate: 'OLD-01',
+    theme: 'Blue Theme',
+    image: 'custom-raven.jpg',
+  }];
+
+  const result = upsertJournalShip({
+    frontier_id: 42,
+    ship_id: 9,
+    kind_short: 'CobraMkIII',
+    kind_full: 'Cobra Mk 3',
+    name: 'New Name',
+    plate: 'NEW-01',
+    theme: 'Current Settings',
+    image: 'cobramkiii.jpg',
+  }, existingShips);
+
+  assert.equal(result.ships.length, 1);
+  assert.equal(result.ship.record_id, 'frontier:42');
+  assert.equal(result.ship.name, 'New Name');
+  assert.equal(result.ship.plate, 'NEW-01');
+  assert.equal(result.ship.theme, 'Blue Theme');
+  assert.equal(result.ship.image, 'custom-raven.jpg');
+
+  const repeated = upsertJournalShip(result.ship, result.ships);
+  assert.equal(repeated.changed, false, 'repeating the same journal identity is idempotent');
+  assert.equal(repeated.ships.length, 1);
+});
+
+test('journal matching migrates legacy names and does not collapse another stable ID', () => {
+  const legacyResult = upsertJournalShip({
+    frontier_id: 42,
+    ship_id: 9,
+    kind_short: 'cobramkiii',
+    kind_full: 'Cobra Mk 3',
+    name: ' Raven ',
+    plate: 'rvn-01',
+    theme: 'Current Settings',
+    image: 'cobramkiii.jpg',
+  }, [{
+    kind_short: 'CobraMkIII', custom_name: 'raven', plate: 'RVN-01',
+    theme: 'Legacy Theme', image: 'legacy.jpg',
+  }]);
+
+  assert.equal(legacyResult.ships.length, 1);
+  assert.equal(legacyResult.ship.frontier_id, '42');
+  assert.equal(legacyResult.ship.theme, 'Legacy Theme');
+  assert.equal('custom_name' in legacyResult.ship, false);
+
+  const separateResult = upsertJournalShip({
+    frontier_id: 43,
+    ship_id: 9,
+    kind_short: 'cobramkiii',
+    kind_full: 'Cobra Mk 3',
+    name: 'Raven',
+    plate: 'RVN-01',
+    theme: 'Current Settings',
+    image: 'cobramkiii.jpg',
+  }, legacyResult.ships);
+
+  assert.equal(separateResult.ships.length, 2);
+  assert.deepEqual(separateResult.ships.map((ship) => ship.frontier_id), ['42', '43']);
+});
+
+test('a reused Frontier ID on a different model does not inherit the sold ship theme', () => {
+  const frontierShips = normalizeFrontierShips({
+    ships: [{ id: 42, name: 'Python', shipName: 'Replacement', shipID: 'NEW-42' }],
+  }, shipList);
+  const merged = mergeFrontierShips(frontierShips, [{
+    frontier_id: '42', source: 'frontier', kind_short: 'cobramkiii',
+    name: 'Sold Ship', plate: 'OLD-42', theme: 'Old Blue', image: 'old.jpg',
+  }]);
+
+  assert.equal(merged.length, 1);
+  assert.equal(merged[0].kind_short, 'python');
+  assert.equal(merged[0].theme, 'Current Settings');
+  assert.equal(merged[0].image, 'python.jpg');
+});

--- a/source_v3/test/frontier-oauth.test.mjs
+++ b/source_v3/test/frontier-oauth.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  filterFrontierAuthArguments,
+  findFrontierAuthCallback,
+  FRONTIER_REDIRECT_URI,
+  parseFrontierAuthCallback,
+} from '../src/Helpers/FrontierOAuth.mjs';
+
+test('Frontier OAuth recognizes only the registered EDHM callback', () => {
+  assert.equal(FRONTIER_REDIRECT_URI, 'edhm://frontier-auth');
+  assert.deepEqual(parseFrontierAuthCallback(
+    'edhm://frontier-auth?code=authorization-code&state=expected-state'
+  ), {
+    url: 'edhm://frontier-auth?code=authorization-code&state=expected-state',
+    code: 'authorization-code',
+    state: 'expected-state',
+    error: '',
+    errorDescription: '',
+  });
+
+  assert.equal(parseFrontierAuthCallback('edhm://other-host?code=nope'), null);
+  assert.equal(parseFrontierAuthCallback('edhm://frontier-auth/unregistered?code=nope'), null);
+  assert.equal(parseFrontierAuthCallback('edhm://user@frontier-auth?code=nope'), null);
+  assert.equal(parseFrontierAuthCallback('https://localhost:3000/edhm-callback?code=nope'), null);
+});
+
+test('Frontier OAuth extracts a callback from operating-system arguments', () => {
+  const callback = 'edhm://frontier-auth?error=access_denied&error_description=Cancelled&state=abc';
+  assert.equal(findFrontierAuthCallback(['--hide', callback]), callback);
+  assert.equal(findFrontierAuthCallback(['--hide', `"${callback}"`]), callback);
+  assert.equal(findFrontierAuthCallback(['--hide', 'not-a-url']), null);
+  assert.deepEqual(
+    filterFrontierAuthArguments(['--hide', callback, `"${callback}"`, '--another']),
+    ['--hide', '--another']
+  );
+});

--- a/source_v3/test/platform-defaults.test.mjs
+++ b/source_v3/test/platform-defaults.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  applyPlatformSettingsDefaults,
+  LINUX_PLAYER_JOURNAL_DEFAULT,
+  WINDOWS_PLAYER_JOURNAL_DEFAULT,
+} from '../src/Helpers/PlatformDefaults.mjs';
+
+test('migrates only untouched journal defaults for the active platform', () => {
+  const linuxSettings = { PlayerJournal: WINDOWS_PLAYER_JOURNAL_DEFAULT };
+  assert.equal(applyPlatformSettingsDefaults(linuxSettings, 'linux'), true);
+  assert.equal(linuxSettings.PlayerJournal, LINUX_PLAYER_JOURNAL_DEFAULT);
+
+  const customSettings = { PlayerJournal: '/mnt/games/custom-journals' };
+  assert.equal(applyPlatformSettingsDefaults(customSettings, 'linux'), false);
+  assert.equal(customSettings.PlayerJournal, '/mnt/games/custom-journals');
+
+  const windowsSettings = { PlayerJournal: LINUX_PLAYER_JOURNAL_DEFAULT };
+  assert.equal(applyPlatformSettingsDefaults(windowsSettings, 'win32'), true);
+  assert.equal(windowsSettings.PlayerJournal, WINDOWS_PLAYER_JOURNAL_DEFAULT);
+});

--- a/static/badges/runtime-electron.svg
+++ b/static/badges/runtime-electron.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="126" height="20" role="img" aria-label="Runtime: Electron">
+  <title>Runtime: Electron</title>
+  <linearGradient id="smooth" x2="0" y2="100%">
+    <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+    <stop offset="1" stop-opacity=".1"/>
+  </linearGradient>
+  <clipPath id="round">
+    <rect width="126" height="20" rx="3" fill="#fff"/>
+  </clipPath>
+  <g clip-path="url(#round)">
+    <rect width="56" height="20" fill="#555"/>
+    <rect x="56" width="70" height="20" fill="#47848f"/>
+    <rect width="126" height="20" fill="url(#smooth)"/>
+  </g>
+  <g fill="#fff" text-anchor="middle" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">
+    <text x="28" y="15" fill="#010101" fill-opacity=".3">Runtime</text>
+    <text x="28" y="14">Runtime</text>
+    <text x="91" y="15" fill="#010101" fill-opacity=".3">Electron</text>
+    <text x="91" y="14">Electron</text>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary

This PR adds Frontier OAuth 2.0 and Companion API fleet synchronization to the EDHM-UI Shipyard. Commanders can authorize EDHM-UI, import their complete owned fleet, and refresh it without relying exclusively on Player Journal history.

It also improves Shipyard identity matching, Linux support, application packaging, and user documentation so the feature behaves consistently on Windows and native Linux installations managing Elite Dangerous through Proton or Wine.

## Why this was needed

The Player Journal only describes ships encountered by the local journal history. It is not a reliable source for reconstructing a Commander's complete current fleet, especially after a fresh installation, missing journals, or ships that have not recently been loaded.

Frontier CAPI provides the authoritative owned fleet, but integrating it safely requires:

- OAuth authorization suitable for a public desktop application;
- secure local token storage;
- a callback flow that works on Windows and Linux;
- stable ship identity so multiple ships of the same model remain distinct;
- merge behavior that preserves existing theme and image customizations;
- clear recovery when authorization is abandoned or expires.

The initial localhost callback approach also caused browser warnings because a temporary local HTTPS server could only use a self-signed certificate. The final implementation uses the registered `edhm://frontier-auth` application protocol instead, eliminating the certificate warning and local port collisions.

## What changed

### Frontier authorization and secure storage

- Added OAuth 2.0 Authorization Code with PKCE using the registered EDHM-UI public client ID and `auth capi` scopes.
- Generates cryptographically random PKCE verifier/challenge and state values for every authorization attempt.
- Validates the exact callback scheme and host and compares OAuth state using a timing-safe check.
- Exchanges and refreshes tokens entirely in the Electron main process.
- Encrypts tokens with Electron `safeStorage` in the application user-data directory.
- Rejects Linux's insecure `basic_text` storage fallback and requires an available desktop keyring.
- Removes invalid or revoked refresh-token authorization and prompts the user to reconnect.
- Keeps access tokens, refresh tokens, authorization codes, and raw CAPI profiles out of renderer IPC and `Shipyard_v3.json`.
- Filters callback arguments, including quoted OS arguments, before forwarding normal application arguments to the renderer.

### Custom application callback

- Replaced the temporary HTTPS localhost callback server and self-signed certificate dependency with `edhm://frontier-auth`.
- Registers the protocol when EDHM-UI starts and forwards callbacks to the existing single running instance.
- Queues an early callback until the Shipyard service is ready.
- Registers `EDHM-UI-V3` as the Windows protocol/friendly application name so Chromium browsers show useful prompt wording.
- Registers `x-scheme-handler/edhm` in the Linux desktop installer and passes callback URLs through `%u`.
- Added an explicit **Cancel Connection** action so closing the browser does not leave the Shipyard waiting until timeout. Late callbacks from a cancelled attempt are ignored.

### Frontier fleet synchronization

- Added Live and Legacy CAPI profile endpoints selected from the active game instance.
- Normalizes both array and ID-keyed Frontier fleet responses.
- Imports the current ship when Frontier returns it separately without creating a duplicate.
- Limits successful profile refreshes to one per minute.
- Shows Connect, Refresh, Disconnect, progress, cancellation, and Commander/fleet status controls in the Shipyard.
- Disconnecting removes stored authorization while retaining imported ships and their customizations.

### Ship identity and customization preservation

- Uses Frontier's owned-ship ID and Player Journal `Loadout.ShipID` as the stable primary identity.
- Keeps multiple ships of the same model separate even when they have the same custom name or displayed identifier.
- Updates renamed ships without losing assigned themes or custom images.
- Migrates legacy ID-less Journal/V2 records by model, name, and identifier when safe.
- Removes duplicate legacy records after a successful stable-ID match.
- Removes sold Frontier-sourced ships while retaining unmatched local Journal/V2 records.
- Prevents a reused Frontier ship ID on a different model from inheriting the sold ship's customization.
- Keeps unknown future ship models visible with a default image.

### Windows, Linux, packaging, and documentation

- Corrected platform-specific default Player Journal paths while preserving user-configured paths.
- Corrected Linux executable casing and package-maker targeting.
- Improved Linux build error propagation and installer executable validation.
- Added Linux installation, build, keyring, protocol, Proton/Wine path, and troubleshooting documentation.
- Added Frontier implementation/security documentation.
- Refreshed README installation guidance and platform/runtime/EDHM badges.

## User impact

Users can now populate the Shipyard directly from their Frontier account, retain per-ship theme assignments across refreshes and renames, and continue using the Journal Monitor to apply the correct theme when changing ships. The external-browser flow no longer presents an unsafe-certificate warning, and an abandoned authorization can be cancelled immediately.

## Validation

- `npm test` - 13 tests passed.
- `npm run package` - Windows x64 package completed.
- `npm run package -- --platform=linux --arch=x64` - Linux x64 package completed.
- `bash -n linux-build.sh public/linux_installer.sh` - shell syntax passed with Git Bash.
- `git diff --check` - passed.
- `npm audit --omit=dev --audit-level=critical` - passed; the existing dependency tree reports one moderate `yauzl` advisory through `zip-lib`, not introduced by this PR.
- Verified packaged Windows metadata, Linux ELF executable name, Linux protocol installer entries, callback/cancellation code in both packaged `app.asar` files, and absence of the localhost/self-signed callback implementation.
- Manually smoke-tested Frontier authorization, browser-to-application callback, fleet import, cancellation recovery, and Windows browser prompt naming.
